### PR TITLE
Delta store implementation and cache flush 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "serde 1.0.126",
  "serde-humanize-rs",
  "serde_json",
+ "thiserror",
  "threescale",
  "threescalers",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
 
 [[package]]
 name = "log"
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/singleton-service/Cargo.toml
+++ b/singleton-service/Cargo.toml
@@ -25,3 +25,4 @@ chrono = "0.4.19"
 threescalers = { git = "https://github.com/3scale-rs/threescalers", branch = "master" }
 anyhow = "1.0"
 url = { git = "https://github.com/3scale-rs/rust-url", branch = "3scale", features = ["serde"] }
+thiserror = "1.0"

--- a/singleton-service/src/service/deltas.rs
+++ b/singleton-service/src/service/deltas.rs
@@ -9,7 +9,6 @@ pub struct AppDelta {
     pub usages: HashMap<String, u32>,
 }
 
-// getter and setter vs dot
 pub struct DeltaStore {
     pub last_update: Option<DateTime<Utc>>,
     pub deltas: HashMap<String, HashMap<String, AppDelta>>,
@@ -59,17 +58,6 @@ impl DeltaStore {
             Ok(DeltaStoreState::Ok)
         }
     }
-
-    /// Method to flush delta store to 3scale SM API.
-    // #[allow(dead_code)]
-    // pub fn flush_deltas(&mut self) -> bool {
-    //     for (service_key, apps) in self.deltas.drain() {
-    //         let report: Report = report(&service_key, &apps).unwrap();
-    //         let request = build_report_request(&report).unwrap();
-    //         dispatch_http_call(, headers: Vec<(&str, &str)>, body: Option<&[u8]>, trailers: Vec<(&str, &str)>, timeout: Duration)
-    //     }
-    //     true
-    // }
 
     fn get_app_delta<'a>(
         app_key: &'a str,

--- a/singleton-service/src/service/deltas.rs
+++ b/singleton-service/src/service/deltas.rs
@@ -2,25 +2,76 @@ use chrono::offset::Utc;
 use chrono::DateTime;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use threescale::structs::ThreescaleData;
+use threescale::structs::{Application, ThreescaleData};
+
+pub struct AppDelta {
+    key_type: String,
+    usages: HashMap<String, u32>,
+}
 
 // getter and setter vs dot
 pub struct DeltaStore {
     pub last_update: Option<DateTime<Utc>>,
-    pub deltas: RefCell<HashMap<String, HashMap<String, u32>>>,
+    pub deltas: HashMap<String, HashMap<String, AppDelta>>,
     pub request_count: u32,
 }
 
 impl DeltaStore {
     /// Update delta store with a new entry of type ThreescaleData. If container size reached, then
     /// initiate delta store flush logic.
-    pub fn update_delta_store(&self, _threescale: &ThreescaleData) -> bool {
-        true
+    pub fn update_delta_store(&mut self, threescale: &ThreescaleData) -> bool {
+        match self.get_service(&threescale.service_id, &threescale.service_token) {
+            Some(service) => match DeltaStore::get_app_delta(&threescale.app_id, service) {
+                Some(app) => {
+                    DeltaStore::update_app_delta(app, threescale);
+                    true
+                }
+                None => {DeltaStore::add_app_delta(service, threescale)}
+            },
+            None => {
+                let mut usages: HashMap<String, AppDelta> = HashMap::new();
+                usages.insert(threescale.app_id.clone(), AppDelta {key_type: "user_key".to_string(), usages: HashMap::new()});
+                self.deltas.insert(threescale.service_id.clone(), usages);
+                true
+            }
+        }
     }
 
     /// Method to flush delta store to 3scale SM API.
     #[allow(dead_code)]
-    pub fn flush_deltas(&self) -> bool {
+    pub fn flush_deltas(&mut self) -> bool {
+        true
+    }
+
+    fn get_app_delta<'a>(
+        app_key: &'a str,
+        service: &'a mut HashMap<String, AppDelta>,
+    ) -> Option<&'a mut AppDelta> {
+        service.get_mut(app_key)
+    }
+
+    fn get_service(
+        &mut self,
+        service_id: &str,
+        service_token: &str,
+    ) -> Option<&mut HashMap<String, AppDelta>> {
+        let key = format!("{}_{}", service_id, service_token);
+        self.deltas.get_mut(&key)
+    }
+
+    fn update_app_delta(app_delta: &mut AppDelta, threescale: &ThreescaleData) -> bool {
+        for (metric, value) in threescale.metrics.borrow().iter() {
+            if app_delta.usages.contains_key(metric) {
+                *app_delta.usages.get_mut(metric).unwrap() += value;
+            } else {
+                app_delta.usages.insert(metric.to_string(), *value);
+            }
+        }
+        true
+    }
+
+    fn add_app_delta(service: &mut HashMap<String, AppDelta>, threescale: &ThreescaleData) -> bool {
+        service.insert(threescale.app_id.clone(), AppDelta{ key_type: "user_key".to_string(), usages: HashMap::new()});
         true
     }
 }

--- a/singleton-service/src/service/deltas.rs
+++ b/singleton-service/src/service/deltas.rs
@@ -1,6 +1,5 @@
 use chrono::offset::Utc;
 use chrono::DateTime;
-use log::{debug, info, warn};
 use std::collections::HashMap;
 use threescale::structs::ThreescaleData;
 

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -31,7 +31,7 @@ pub fn _start() {
             delta_store: DeltaStore {
                 last_update: None,
                 request_count: 0,
-                deltas: RefCell::new(HashMap::new()),
+                deltas: HashMap::new(),
             },
         })
     });

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -125,7 +125,7 @@ impl RootContext for SingletonService {
                         // TODO: Handle update failure
                         let threescale: ThreescaleData = message_received.data;
                         if message_received.update_cache_from_singleton {
-                            self.update_application_cache(&threescale);
+                            self.update_application_cache(&threescale).unwrap();
                         }
                         // TODO : Handle delta store update failure.
                         self.delta_store.update_delta_store(&threescale).unwrap();
@@ -279,7 +279,7 @@ impl SingletonService {
             let request = build_report_request(&report).unwrap();
             info!("report : {:?}", report);
             // TODO: Handle http local failure
-            self.perform_http_call(&request);
+            self.perform_http_call(&request).unwrap();
         }
     }
 }

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -127,40 +127,40 @@ impl RootContext for SingletonService {
     fn on_tick(&mut self) {
         // This is just a demo of a single Report Call to test the Report call untill bulk requests are implemented.
         info!("onTick triggerd");
-        let report: Report = report().unwrap();
-        let request = build_report_request(&report).unwrap();
-        let (uri, body) = request.uri_and_body();
-        info!("request: {:?}", request);
-        let headers = request
-            .headers
-            .iter()
-            .map(|(key, value)| (key.as_str(), value.as_str()))
-            .collect::<Vec<_>>();
-        let upstream = Upstream {
-            name: "3scale-SM-API".to_string(),
-            url: "https://su1.3scale.net".parse().unwrap(),
-            timeout: Duration::from_millis(5000),
-        };
-        let call_token = match upstream.call(
-            self,
-            uri.as_ref(),
-            request.method.as_str(),
-            headers,
-            body.map(str::as_bytes),
-            None,
-            None,
-        ) {
-            Ok(call_token) => call_token,
-            Err(e) => {
-                info!("Error: {:?}", e);
-                // TODO : Handle error properly with a suitable retry mechanism.
-                panic!("Error: {:?}", e)
-            }
-        };
-        info!(
-            "threescale_cache_singleton: on_http_request_headers: call token is {}",
-            call_token
-        );
+        // let report: Report = report().unwrap();
+        // let request = build_report_request(&report).unwrap();
+        // let (uri, body) = request.uri_and_body();
+        // info!("request: {:?}", request);
+        // let headers = request
+        //     .headers
+        //     .iter()
+        //     .map(|(key, value)| (key.as_str(), value.as_str()))
+        //     .collect::<Vec<_>>();
+        // let upstream = Upstream {
+        //     name: "3scale-SM-API".to_string(),
+        //     url: "https://su1.3scale.net".parse().unwrap(),
+        //     timeout: Duration::from_millis(5000),
+        // };
+        // let call_token = match upstream.call(
+        //     self,
+        //     uri.as_ref(),
+        //     request.method.as_str(),
+        //     headers,
+        //     body.map(str::as_bytes),
+        //     None,
+        //     None,
+        // ) {
+        //     Ok(call_token) => call_token,
+        //     Err(e) => {
+        //         info!("Error: {:?}", e);
+        //         // TODO : Handle error properly with a suitable retry mechanism.
+        //         panic!("Error: {:?}", e)
+        //     }
+        // };
+        // info!(
+        //     "threescale_cache_singleton: on_http_request_headers: call token is {}",
+        //     call_token
+        // );
     }
 }
 

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -218,7 +218,9 @@ impl SingletonService {
 
     /// This is a helper method to send http requests. Both Report and Auth calls will use this method to
     /// send http requests after building relevant threescalers request type.
+    /// TODO : Handle http callout failure from proxy side.
     fn perform_http_call(&self, request: &Request) {
+        // TODO: read upstream from config when configuration parsing is re-implemented.
         let upstream = Upstream {
             name: "3scale-SM-API".to_string(),
             url: "https://su1.3scale.net".parse().unwrap(),

--- a/singleton-service/src/service/report.rs
+++ b/singleton-service/src/service/report.rs
@@ -12,6 +12,7 @@ use threescalers::{
     usage::Usage,
 };
 
+#[derive(Debug)]
 pub struct Report {
     service_id: String,
     service_token: String,
@@ -36,10 +37,10 @@ impl Report {
 /// to create a report, which is the proxy level representation. Then it will be used to build the report request
 /// which is of threescalers Report request type.
 pub fn report<'a>(
-    service_id: &'a str,
+    key: &'a str,
     apps: &'a HashMap<String, AppDelta>,
 ) -> Result<Report, anyhow::Error> {
-    let metrics = [("hits", "1"), ("hits.79419", "1")].to_vec();
+    let keys = key.split('_').collect::<Vec<_>>();
     let mut usages_map: HashMap<String, Vec<(String, String)>> = HashMap::new();
     for e in apps {
         let (app_id, app_deltas): (&String, &AppDelta) = e;
@@ -52,9 +53,8 @@ pub fn report<'a>(
     }
     //usages_map.insert("46de54605a1321aa3838480c5fa91bcc".to_string(), metrics);
     Ok(Report {
-        service_id: service_id.to_string(),
-        service_token: "6705c7d02e9a899d4db405dc1413361611e4250dfd12ec3dcbcea8c3de7cdd29"
-            .to_string(),
+        service_id: keys[0].to_string(),
+        service_token: keys[1].to_string(),
         usages: usages_map,
     })
 }


### PR DESCRIPTION
This PR adds delta store API to add/update deltas from the singleton service and cache flush implementation. `onTick` method contains a sample scenario where delta store capacity is 2 and cache flush operation after 2 entries are added to the delta store.  