### PR TITLE
Fetched inputs from request headers and code restructured

### DIFF
--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -278,19 +278,11 @@ impl Context for CacheFilter {
                         return;
                     }
                 }
-<<<<<<< HEAD
 
                 info!(
                     "data received and parsed from callout with token :{}",
                     token_id
                 );
-=======
-                info!(
-                    "Data received and parsed from callout with token :{}",
-                    token_id
-                );
-                self.resume_http_request();
->>>>>>> Minor cases caught under dev deployment
             }
             None => {
                 info!("Found nothing in the response with token: {}", token_id);

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -46,6 +46,14 @@ enum AuthResponseError {
     NegativeTimeErr,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum AuthResponseError {
+    #[error("failure to follow cache hit flow")]
+    CacheHitErr(#[from] CacheHitError),
+    #[error("conversion from i64 time to u64 duration failed")]
+    NegativeTimeErr,
+}
+
 pub struct CacheFilter {
     pub context_id: u32,
     pub config: FilterConfig,

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -278,11 +278,19 @@ impl Context for CacheFilter {
                         return;
                     }
                 }
+<<<<<<< HEAD
 
                 info!(
                     "data received and parsed from callout with token :{}",
                     token_id
                 );
+=======
+                info!(
+                    "Data received and parsed from callout with token :{}",
+                    token_id
+                );
+                self.resume_http_request();
+>>>>>>> Minor cases caught under dev deployment
             }
             None => {
                 info!("Found nothing in the response with token: {}", token_id);

--- a/cache-filter/src/filter/root.rs
+++ b/cache-filter/src/filter/root.rs
@@ -5,7 +5,7 @@ use proxy_wasm::{
     traits::{Context, HttpContext, RootContext},
     types::{ContextType, LogLevel},
 };
-use threescale::structs::ThreescaleData;
+use threescale::structs::{CacheKey, ThreescaleData};
 
 #[no_mangle]
 pub fn _start() {
@@ -58,7 +58,7 @@ impl RootContext for CacheFilterRoot {
             context_id: context,
             config: self.config.clone(),
             update_cache_from_singleton: false,
-            cache_key: String::new(),
+            cache_key: CacheKey::default(),
             req_data: ThreescaleData::default(),
         }))
     }

--- a/cache-filter/src/utils.rs
+++ b/cache-filter/src/utils.rs
@@ -122,14 +122,14 @@ pub fn period_from_response(res_period: &ResponsePeriod) -> Period {
     }
 }
 
-pub fn period_from_response(res_period: &Response_Period) -> Period {
+pub fn period_from_response(res_period: &ResponsePeriod) -> Period {
     match res_period {
-        Response_Period::Minute => Period::Minute,
-        Response_Period::Hour => Period::Hour,
-        Response_Period::Day => Period::Day,
-        Response_Period::Week => Period::Week,
-        Response_Period::Month => Period::Month,
-        Response_Period::Year => Period::Year,
-        Response_Period::Eternity => Period::Eternity,
+        ResponsePeriod::Minute => Period::Minute,
+        ResponsePeriod::Hour => Period::Hour,
+        ResponsePeriod::Day => Period::Day,
+        ResponsePeriod::Week => Period::Week,
+        ResponsePeriod::Month => Period::Month,
+        ResponsePeriod::Year => Period::Year,
+        ResponsePeriod::Eternity => Period::Eternity,
     }
 }

--- a/cache-filter/src/utils.rs
+++ b/cache-filter/src/utils.rs
@@ -121,3 +121,15 @@ pub fn period_from_response(res_period: &ResponsePeriod) -> Period {
         ResponsePeriod::Eternity => Period::Eternity,
     }
 }
+
+pub fn period_from_response(res_period: &Response_Period) -> Period {
+    match res_period {
+        Response_Period::Minute => Period::Minute,
+        Response_Period::Hour => Period::Hour,
+        Response_Period::Day => Period::Day,
+        Response_Period::Week => Period::Week,
+        Response_Period::Month => Period::Month,
+        Response_Period::Year => Period::Year,
+        Response_Period::Eternity => Period::Eternity,
+    }
+}

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use threescale::upstream::*;
 use threescale::{
     proxy::cache::{get_application_from_cache, set_application_to_cache},
-    structs::{Message, ThreescaleData},
+    structs::{AppIdentifier, CacheKey, Message, ServiceId, ServiceToken, ThreescaleData, UserKey},
     utils::update_metrics,
 };
 use threescalers::http::Request;
@@ -153,10 +153,11 @@ impl RootContext for SingletonService {
         .cloned()
         .collect();
         let threescale1 = ThreescaleData {
-            app_id: "46de54605a1321aa3838480c5fa91bcc".to_string(),
-            service_id: "2555417902188".to_string(),
-            service_token: "6705c7d02e9a899d4db405dc1413361611e4250dfd12ec3dcbcea8c3de7cdd29"
-                .to_string(),
+            app_id: AppIdentifier::UserKey(UserKey::from("46de54605a1321aa3838480c5fa91bcc")),
+            service_id: ServiceId::from("2555417902188"),
+            service_token: ServiceToken::from(
+                "6705c7d02e9a899d4db405dc1413361611e4250dfd12ec3dcbcea8c3de7cdd29",
+            ),
             metrics: RefCell::new(metrics1),
         };
         let metrics2: HashMap<String, u64> = [
@@ -167,10 +168,11 @@ impl RootContext for SingletonService {
         .cloned()
         .collect();
         let threescale2 = ThreescaleData {
-            app_id: "de90b3d58dc5449572d2fdb7ae0af61a".to_string(),
-            service_id: "2555417889374".to_string(),
-            service_token: "e1abc8f29e6ba7dfed3fcc9c5399be41f7a881f85fa11df68b93a5d800c3c07a"
-                .to_string(),
+            app_id: AppIdentifier::UserKey(UserKey::from("de90b3d58dc5449572d2fdb7ae0af61a")),
+            service_id: ServiceId::from("2555417889374"),
+            service_token: ServiceToken::from(
+                "e1abc8f29e6ba7dfed3fcc9c5399be41f7a881f85fa11df68b93a5d800c3c07a",
+            ),
             metrics: RefCell::new(metrics2),
         };
         let state1 = self.delta_store.update_delta_store(&threescale1).unwrap();
@@ -202,24 +204,29 @@ impl SingletonService {
     /// update_application_cache method updates the local application cache if the cache update
     /// fails from the cache filter for a particular request
     fn update_application_cache(&self, threescale: &ThreescaleData) -> Result<(), anyhow::Error> {
-        let cache_key = format!("{}_{}", threescale.app_id, threescale.service_id);
-        match get_application_from_cache(&cache_key) {
+        let cache_key = CacheKey::from(&threescale.service_id, &threescale.app_id);
+        match get_application_from_cache(&cache_key.as_string()) {
             Some((mut application, _)) => {
                 let is_updated: bool = update_metrics(threescale, &mut application);
                 if is_updated {
-                    if !set_application_to_cache(&cache_key, &application, false, None) {
-                        anyhow::bail!(SingletonServiceError::SetCacheFailure(cache_key.clone()))
+                    if !set_application_to_cache(&cache_key.as_string(), &application, false, None)
+                    {
+                        anyhow::bail!(SingletonServiceError::SetCacheFailure(
+                            cache_key.as_string()
+                        ))
                     }
                     Ok(())
                 } else {
                     anyhow::bail!(SingletonServiceError::UpdateMetricsFailure(
-                        threescale.app_id.clone()
+                        threescale.app_id.as_string()
                     ))
                 }
             }
             None => {
                 info!("No app in shared data");
-                anyhow::bail!(SingletonServiceError::GetCacheFailure(cache_key.clone()))
+                anyhow::bail!(SingletonServiceError::GetCacheFailure(
+                    cache_key.as_string()
+                ))
             }
         }
     }

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -5,12 +5,12 @@ use std::time::Duration;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub enum Period {
-    Minute = 60,
-    Hour = 3600,
-    Day = 86400,
-    Week = 604800,
-    Month = 2592000,
-    Year = 31536000,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Month,
+    Year,
     Eternity,
 }
 

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -45,11 +45,168 @@ pub struct UsageReport {
     pub max_value: u64,
 }
 
+#[repr(transparent)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AppId(String);
+#[repr(transparent)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AppKey(String);
+#[repr(transparent)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserKey(String);
+
+impl AsRef<str> for AppId {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<str> for AppKey {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<str> for UserKey {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for UserKey {
+    fn from(a: &str) -> Self {
+        Self(a.to_string())
+    }
+}
+
+impl From<&str> for AppId {
+    fn from(a: &str) -> Self {
+        Self(a.to_string())
+    }
+}
+
+impl From<&str> for AppKey {
+    fn from(a: &str) -> Self {
+        Self(a.to_string())
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceToken(String);
+#[repr(transparent)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceId(String);
+
+impl AsRef<str> for ServiceToken {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<str> for ServiceId {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for ServiceToken {
+    fn from(a: &str) -> Self {
+        Self(a.to_string())
+    }
+}
+
+impl From<&str> for ServiceId {
+    fn from(a: &str) -> Self {
+        Self(a.to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheKey(ServiceId, AppIdentifier);
+
+impl<'a> CacheKey {
+    pub fn as_string(&self) -> String {
+        format!("{}_{}", self.0 .0, self.1.as_string())
+    }
+
+    pub fn default() -> CacheKey {
+        CacheKey(
+            ServiceId(String::new()),
+            AppIdentifier::UserKey(UserKey(String::new())),
+        )
+    }
+
+    pub fn service_id(&'a self) -> &'a ServiceId {
+        &self.0
+    }
+
+    pub fn app_id(&'a self) -> &'a AppIdentifier {
+        &self.1
+    }
+
+    pub fn from(a: &ServiceId, b: &AppIdentifier) -> CacheKey {
+        CacheKey {
+            0: a.clone(),
+            1: b.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AppIdentifier {
+    AppId(AppId, Option<AppKey>),
+    UserKey(UserKey),
+}
+
+impl From<AppId> for AppIdentifier {
+    fn from(a: AppId) -> Self {
+        AppIdentifier::AppId(a, None)
+    }
+}
+
+impl From<(AppId, AppKey)> for AppIdentifier {
+    fn from(a: (AppId, AppKey)) -> Self {
+        AppIdentifier::AppId(a.0, Some(a.1))
+    }
+}
+
+impl From<UserKey> for AppIdentifier {
+    fn from(u: UserKey) -> Self {
+        AppIdentifier::UserKey(u)
+    }
+}
+
+impl AppIdentifier {
+    // This cannot return a reference because app_id:app_key needs to be generated
+    pub fn as_string(&self) -> String {
+        match self {
+            AppIdentifier::AppId(AppId(id), key) => {
+                let mut res: String = id.clone();
+                if let Some(AppKey(app_key)) = key {
+                    res.push(':');
+                    res.push_str(app_key.as_str());
+                }
+                res
+            }
+            AppIdentifier::UserKey(UserKey(user_key)) => user_key.clone(),
+        }
+    }
+
+    pub fn appid_from_str(s: &str) -> AppIdentifier {
+        let v: Vec<&str> = s.split(':').collect();
+        if v.len() == 1 {
+            return AppIdentifier::AppId(AppId(v[0].to_owned()), Some(AppKey(v[1].to_owned())));
+        }
+        AppIdentifier::AppId(AppId(v[0].to_owned()), None)
+    }
+}
+
 // Threescale's Application representation for cache
 #[derive(Serialize, Deserialize)]
 pub struct Application {
-    pub app_id: String,
-    pub service_id: String,
+    pub app_id: AppIdentifier,
+    pub service_id: ServiceId,
     pub local_state: HashMap<String, UsageReport>,
     pub metric_hierarchy: HashMap<String, Vec<String>>,
 }
@@ -58,18 +215,18 @@ pub struct Application {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ThreescaleData {
     // TODO: App_key, user_key is also possible as an input
-    pub app_id: String,
-    pub service_id: String,
-    pub service_token: String,
+    pub app_id: AppIdentifier,
+    pub service_id: ServiceId,
+    pub service_token: ServiceToken,
     pub metrics: RefCell<HashMap<String, u64>>,
 }
 
 impl Default for ThreescaleData {
     fn default() -> Self {
         ThreescaleData {
-            app_id: "".to_owned(),
-            service_id: "".to_owned(),
-            service_token: "".to_owned(),
+            app_id: AppIdentifier::UserKey(UserKey("".to_owned())),
+            service_id: ServiceId("".to_owned()),
+            service_token: ServiceToken("".to_owned()),
             metrics: RefCell::new(HashMap::new()),
         }
     }

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -5,12 +5,12 @@ use std::time::Duration;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub enum Period {
-    Minute,
-    Hour,
-    Day,
-    Week,
-    Month,
-    Year,
+    Minute = 60,
+    Hour = 3600,
+    Day = 86400,
+    Week = 604800,
+    Month = 2592000,
+    Year = 31536000,
     Eternity,
 }
 


### PR DESCRIPTION
This PR completes the basic cache filter requirements as I've added the code to fetch inputs from the request headers and restructured for easy type identification from the singleton side of keys. Please let me know if you find any mistakes that I overlooked. Thanks! :)

Note: Only the last commit is relevant because reset of them came automatically as I updated my local fork during the creation of this PR.