### PR TITLE
Auth call and app identifier changes for singleton service

### DIFF
--- a/singleton-service/src/configuration.rs
+++ b/singleton-service/src/configuration.rs
@@ -1,2 +1,3 @@
 pub mod delta;
 pub mod service;
+pub mod test;

--- a/singleton-service/src/configuration.rs
+++ b/singleton-service/src/configuration.rs
@@ -1,1 +1,2 @@
+pub mod delta;
 pub mod service;

--- a/singleton-service/src/configuration/delta.rs
+++ b/singleton-service/src/configuration/delta.rs
@@ -1,0 +1,31 @@
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Deserialize, Debug)]
+#[serde(default)]
+pub struct DeltaStoreConfig {
+    /// Capacity of the delta store.
+    capacity: u64,
+
+    /// Flush duration for periodical cache flush in case of low traffic.
+    #[serde(with = "serde_humanize_rs")]
+    periodical_flush: Duration,
+
+    /// Retry duration in case threescale backend is offline.
+    #[serde(with = "serde_humanize_rs")]
+    retry_duration: Duration,
+
+    /// Capacity of the await queue in case threescale backend is offline.
+    await_queue_capacity: u64,
+}
+
+impl Default for DeltaStoreConfig {
+    fn default() -> Self {
+        DeltaStoreConfig {
+            capacity: 100,
+            periodical_flush: Duration::from_secs(60),
+            retry_duration: Duration::from_secs(10),
+            await_queue_capacity: 200,
+        }
+    }
+}

--- a/singleton-service/src/configuration/service.rs
+++ b/singleton-service/src/configuration/service.rs
@@ -1,4 +1,5 @@
 use crate::configuration::delta::DeltaStoreConfig;
+use crate::configuration::test::TestConfiguration;
 use serde::Deserialize;
 use std::time::Duration;
 use threescale::upstream::Upstream;
@@ -11,6 +12,9 @@ pub struct ServiceConfig {
 
     /// Delta store configuration.
     pub delta_store_config: DeltaStoreConfig,
+
+    /// Temporary test configuration.
+    pub test_config: Option<TestConfiguration>,
 }
 
 impl Default for ServiceConfig {
@@ -22,6 +26,7 @@ impl Default for ServiceConfig {
                 timeout: Duration::from_millis(5000),
             },
             delta_store_config: DeltaStoreConfig::default(),
+            test_config: None,
         }
     }
 }

--- a/singleton-service/src/configuration/service.rs
+++ b/singleton-service/src/configuration/service.rs
@@ -1,42 +1,27 @@
+use crate::configuration::delta::DeltaStoreConfig;
 use serde::Deserialize;
 use std::time::Duration;
+use threescale::upstream::Upstream;
 
 #[derive(Deserialize, Debug)]
 #[serde(default)]
 pub struct ServiceConfig {
-    /// Threescale cluster name that indicates threescale backend that includes SM API. Should provide the cluster
-    /// name of the threescale cluster in the envoy.yaml file.
-    threescale_cluster: String,
+    /// Upstream configuration.
+    pub upstream_config: Upstream,
 
-    /// Authroize call timeout.
-    #[serde(with = "serde_humanize_rs")]
-    threescale_auth_timeout: Duration,
-
-    /// Size of the local cache container.
-    local_cache_container_size: i32,
-
-    /// Minimum tick period for the periodical cache update in case of low traffic.
-    #[serde(with = "serde_humanize_rs")]
-    minimum_tick: Duration,
-
-    /// Maximum tick period for the periodical cache update in case of low traffic.
-    #[serde(with = "serde_humanize_rs")]
-    maximum_tick: Duration,
-
-    /// Retry duration in case threescale backend gets offline.
-    #[serde(with = "serde_humanize_rs")]
-    retry_duration: Duration,
+    /// Delta store configuration.
+    pub delta_store_config: DeltaStoreConfig,
 }
 
 impl Default for ServiceConfig {
     fn default() -> Self {
         ServiceConfig {
-            threescale_cluster: "threescale_SM_API".to_owned(),
-            threescale_auth_timeout: Duration::from_secs(5),
-            local_cache_container_size: 100,
-            minimum_tick: Duration::from_secs(5),
-            maximum_tick: Duration::from_secs(60),
-            retry_duration: Duration::from_secs(20),
+            upstream_config: Upstream {
+                name: "outbound|443||su1.3scale.net".to_owned(),
+                url: "https://su1.3scale.net".parse().unwrap(),
+                timeout: Duration::from_millis(5000),
+            },
+            delta_store_config: DeltaStoreConfig::default(),
         }
     }
 }

--- a/singleton-service/src/configuration/test.rs
+++ b/singleton-service/src/configuration/test.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct TestConfiguration {
+    pub service_id_1: String,
+    pub service_token_1: String,
+    pub application_1: String,
+    pub service_id_2: String,
+    pub service_token_2: String,
+    pub application_2: String,
+}

--- a/singleton-service/src/service.rs
+++ b/singleton-service/src/service.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod deltas;
 pub mod proxy;
 pub mod report;

--- a/singleton-service/src/service/auth.rs
+++ b/singleton-service/src/service/auth.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use log::debug;
+use threescalers::{
+    api_call::{ApiCall, Kind},
+    application::Application,
+    extensions::{self},
+    http::Request,
+    credentials::*,
+    service::Service,
+    transaction::Transaction,
+};
+
+pub struct Auth {
+    service_id: String,
+    service_token: String,
+    app_id: String,
+}
+
+impl Auth {
+    pub fn service_id(&self) -> &str {
+        self.service_id.as_str()
+    }
+
+    pub fn service_token(&self) -> &str {
+        self.service_token.as_str()
+    }
+
+    pub fn app_id(&self) -> &str {
+        self.app_id.as_str()
+    }
+}
+
+pub fn auth_apps(service_key: String, app_keys: Vec<String>) -> Vec<Auth> {
+    let keys = service_key.split('_').collect::<Vec<_>>();
+    app_keys
+        .iter()
+        .map(|app_key| auth(keys[0].to_string(), keys[1].to_string(), app_key.clone()))
+        .collect::<Vec<_>>()
+}
+
+pub fn auth(service_id: String, service_token: String, app_id: String) -> Auth {
+    Auth {
+        service_id,
+        service_token,
+        app_id,
+    }
+}
+
+pub fn build_auth_request(auth: &Auth) -> Result<Request, anyhow::Error> {
+    let creds = Credentials::ServiceToken(ServiceToken::from(auth.service_token()));
+    let svc = Service::new(auth.service_id(), creds);
+    let app = Application::from_user_key(auth.app_id());
+    let txn = vec![(Transaction::new(&app, None, None, None))];
+    let extensions = extensions::List::new().push(extensions::Extension::Hierarchy);
+    let mut api_call = ApiCall::builder(&svc);
+    let api_call = api_call
+        .transactions(&txn)
+        .extensions(&extensions)
+        .kind(Kind::Authorize)
+        .build()?;
+    Ok(Request::from(&api_call))
+}

--- a/singleton-service/src/service/auth.rs
+++ b/singleton-service/src/service/auth.rs
@@ -1,5 +1,5 @@
 use log::debug;
-use std::collections::HashMap;
+use threescale::structs::AppIdentifier;
 use threescalers::{
     api_call::{ApiCall, Kind},
     application::Application,
@@ -10,10 +10,11 @@ use threescalers::{
     transaction::Transaction,
 };
 
+/// Proxy level representation for authorization request.
 pub struct Auth {
     pub service_id: String,
     pub service_token: String,
-    pub app_id: String,
+    pub app_id: AppIdentifier,
 }
 
 impl Auth {
@@ -25,20 +26,24 @@ impl Auth {
         self.service_token.as_str()
     }
 
-    pub fn app_id(&self) -> &str {
-        self.app_id.as_str()
+    pub fn app_id(&self) -> &AppIdentifier {
+        &self.app_id
     }
 }
 
-pub fn auth_apps(service_key: String, app_keys: Vec<String>) -> Vec<Auth> {
+/// Create a vector of Auth objects for a service. Take service_key(service_id + service_token)
+/// and apps_keys of type Vec<AppIdentifier> as arguments to the function and returns Vec<Auth>.
+pub fn auth_apps(service_key: String, app_keys: Vec<AppIdentifier>) -> Vec<Auth> {
     let keys = service_key.split('_').collect::<Vec<_>>();
     app_keys
         .iter()
-        .map(|app_key| auth(keys[0].to_string(), keys[1].to_string(), app_key.clone()))
+        .map(|app| auth(keys[0].to_string(), keys[1].to_string(), app.clone()))
         .collect::<Vec<_>>()
 }
 
-pub fn auth(service_id: String, service_token: String, app_id: String) -> Auth {
+/// Create a Auth object for an application. Take service_id, service_token and app_id of type
+/// AppIdentifier and returns an Auth object.
+pub fn auth(service_id: String, service_token: String, app_id: AppIdentifier) -> Auth {
     Auth {
         service_id,
         service_token,
@@ -46,11 +51,30 @@ pub fn auth(service_id: String, service_token: String, app_id: String) -> Auth {
     }
 }
 
+/// Create a Request of type Authorize. Take an object of type Auth as argument to the function
+/// and returns Result<Request, anyhow::Error>.
 pub fn build_auth_request(auth: &Auth) -> Result<Request, anyhow::Error> {
     let creds = Credentials::ServiceToken(ServiceToken::from(auth.service_token()));
     let svc = Service::new(auth.service_id(), creds);
-    let app = Application::from_user_key(auth.app_id());
+    let app;
+    match auth.app_id() {
+        AppIdentifier::UserKey(_user_key) => {
+            debug!("AppIdentifier UserKey: {}", auth.app_id().as_string());
+            app = Application::from_user_key(auth.app_id().as_string())
+        }
+        AppIdentifier::AppId(_app_id, None) => {
+            debug!("AppIdentifier AppId : {}", auth.app_id().as_string());
+            app = Application::from_app_id(auth.app_id().as_string())
+        }
+        AppIdentifier::AppId(_app_id, _app_key) => {
+            let app_key = auth.app_id().as_string();
+            debug!("AppIdentifier AppId+AppKey : {}", app_key);
+            let keys = app_key.split('_').collect::<Vec<_>>();
+            app = Application::from_app_id_and_key(keys[0], keys[1])
+        }
+    }
     let txn = vec![(Transaction::new(&app, None, None, None))];
+    // TODO : Enable list keys extension.
     let extensions = extensions::List::new().push(extensions::Extension::Hierarchy);
     let mut api_call = ApiCall::builder(&svc);
     let api_call = api_call

--- a/singleton-service/src/service/auth.rs
+++ b/singleton-service/src/service/auth.rs
@@ -1,19 +1,19 @@
-use std::collections::HashMap;
 use log::debug;
+use std::collections::HashMap;
 use threescalers::{
     api_call::{ApiCall, Kind},
     application::Application,
+    credentials::*,
     extensions::{self},
     http::Request,
-    credentials::*,
     service::Service,
     transaction::Transaction,
 };
 
 pub struct Auth {
-    service_id: String,
-    service_token: String,
-    app_id: String,
+    pub service_id: String,
+    pub service_token: String,
+    pub app_id: String,
 }
 
 impl Auth {

--- a/singleton-service/src/service/deltas.rs
+++ b/singleton-service/src/service/deltas.rs
@@ -1,21 +1,34 @@
 use chrono::offset::Utc;
 use chrono::DateTime;
 use std::collections::HashMap;
-use threescale::structs::ThreescaleData;
+use threescale::structs::{AppIdentifier, ThreescaleData};
 
-#[derive(Clone)]
-pub struct AppDelta {
-    pub key_type: String,
-    pub usages: HashMap<String, u64>,
-}
-
+/// DeltaStore is an in-memory storage built using nested hashmaps to store deltas for different
+/// metrics related to different applications until they gets flushed. Data stored in delta store
+/// is structured in a way that is favourable cache flush operation.
+/// (minimal computations required before flushing)
 pub struct DeltaStore {
+    // Represents the previous cache flush time in UTC. This will be used to flush cache in case of
+    // a low network traffic scenario.
     pub last_update: Option<DateTime<Utc>>,
-    pub deltas: HashMap<String, HashMap<String, AppDelta>>,
+
+    // Represents a hierarchical storage of deltas.
+    // Hierarchy => - Service
+    //                - Application
+    //                  - Metric : Value
+    pub deltas: HashMap<String, HashMap<AppIdentifier, HashMap<String, u64>>>,
+
+    // Represents the request count. Gets incremented by 1 for each request passing
+    // through the proxy. Used together with the capacity attribute to implement a
+    // container filling mechansim for cache flush in case of high network traffic scenarios.
     pub request_count: u32,
+
+    // Represents the capacity of the cache container.
     pub capacity: u32,
 }
 
+/// DeltaStoreState represents the state of the delta store. Singleton service uses this
+/// state to initiate cache flush when delta store gets filled.
 #[derive(PartialEq)]
 pub enum DeltaStoreState {
     Flush,
@@ -23,34 +36,30 @@ pub enum DeltaStoreState {
 }
 
 impl DeltaStore {
-    /// Update delta store with a new entry of type ThreescaleData. If container size reached, then
-    /// initiate delta store flush logic.
+    /// Method to update delta store. Handles scenarios like updating existing metrics,
+    /// adding new services, applications with new metrics. Gets called for each message
+    /// received through the message queue.
     pub fn update_delta_store(
         &mut self,
         threescale: &ThreescaleData,
     ) -> Result<DeltaStoreState, anyhow::Error> {
-        match self.get_service(
+        match self.get_mut_service(
             threescale.service_id.as_ref(),
             threescale.service_token.as_ref(),
         ) {
-            Some(service) => {
-                match DeltaStore::get_app_delta(&threescale.app_id.as_string(), service) {
-                    Some(app) => {
-                        DeltaStore::update_app_delta(app, threescale);
-                    }
-                    None => {
-                        DeltaStore::add_app_delta(service, threescale);
-                    }
+            Some(service) => match DeltaStore::get_mut_app_delta(&threescale.app_id, service) {
+                Some(app) => {
+                    DeltaStore::update_app_delta(app, threescale);
                 }
-            }
+                None => {
+                    DeltaStore::add_app_delta(service, threescale);
+                }
+            },
             None => {
-                let mut usages: HashMap<String, AppDelta> = HashMap::new();
+                let mut usages: HashMap<AppIdentifier, HashMap<String, u64>> = HashMap::new();
                 usages.insert(
-                    threescale.app_id.as_string(),
-                    AppDelta {
-                        key_type: "user_key".to_string(),
-                        usages: threescale.metrics.borrow().clone(),
-                    },
+                    threescale.app_id.clone(),
+                    threescale.metrics.borrow().clone(),
                 );
                 let delta_key = format!(
                     "{}_{}",
@@ -68,40 +77,40 @@ impl DeltaStore {
         }
     }
 
-    fn get_app_delta<'a>(
-        app_key: &'a str,
-        service: &'a mut HashMap<String, AppDelta>,
-    ) -> Option<&'a mut AppDelta> {
-        service.get_mut(app_key)
+    fn get_mut_app_delta<'a>(
+        app: &'a AppIdentifier,
+        service: &'a mut HashMap<AppIdentifier, HashMap<String, u64>>,
+    ) -> Option<&'a mut HashMap<String, u64>> {
+        service.get_mut(app)
     }
 
-    fn get_service(
+    fn get_mut_service(
         &mut self,
         service_id: &str,
         service_token: &str,
-    ) -> Option<&mut HashMap<String, AppDelta>> {
+    ) -> Option<&mut HashMap<AppIdentifier, HashMap<String, u64>>> {
         let key = format!("{}_{}", service_id, service_token);
         self.deltas.get_mut(&key)
     }
 
-    fn update_app_delta(app_delta: &mut AppDelta, threescale: &ThreescaleData) -> bool {
+    fn update_app_delta(app_delta: &mut HashMap<String, u64>, threescale: &ThreescaleData) -> bool {
         for (metric, value) in threescale.metrics.borrow().iter() {
-            if app_delta.usages.contains_key(metric) {
-                *app_delta.usages.get_mut(metric).unwrap() += value;
+            if app_delta.contains_key(metric) {
+                *app_delta.get_mut(metric).unwrap() += value;
             } else {
-                app_delta.usages.insert(metric.to_string(), *value);
+                app_delta.insert(metric.to_string(), *value);
             }
         }
         true
     }
 
-    fn add_app_delta(service: &mut HashMap<String, AppDelta>, threescale: &ThreescaleData) -> bool {
+    fn add_app_delta(
+        service: &mut HashMap<AppIdentifier, HashMap<String, u64>>,
+        threescale: &ThreescaleData,
+    ) -> bool {
         service.insert(
-            threescale.app_id.as_string(),
-            AppDelta {
-                key_type: "user_key".to_string(),
-                usages: threescale.metrics.borrow().clone(),
-            },
+            threescale.app_id.clone(),
+            threescale.metrics.borrow().clone(),
         );
         true
     }

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -274,12 +274,21 @@ impl SingletonService {
     /// flush local cache. This will be called when delta store is full or when timer based cache flush is required.
     fn flush_local_cache(&mut self) {
         let deltas = self.flush_delta_store();
+        let mut auth_keys = HashMap::new();
         for (key, apps) in deltas {
             let report: Report = report(&key, &apps).unwrap();
             let request = build_report_request(&report).unwrap();
+            let app_keys = apps.keys().cloned().collect::<Vec<_>>();
+            auth_keys.insert(key, app_keys);
             info!("report : {:?}", report);
             // TODO: Handle http local failure
             self.perform_http_call(&request).unwrap();
         }
+        //deltas.clear()
+        self.update_local_cache(auth_keys);
+    }
+
+    fn update_local_cache(&self, auth_keys: HashMap<String, Vec<String>>) {
+
     }
 }

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -158,10 +158,29 @@ impl RootContext for SingletonService {
         .cloned()
         .collect();
         let threescale1 = ThreescaleData {
-            app_id: AppIdentifier::UserKey(UserKey::from("46de54605a1321aa3838480c5fa91bcc")),
-            service_id: ServiceId::from("2555417902188"),
+            app_id: AppIdentifier::UserKey(UserKey::from(
+                self.config
+                    .test_config
+                    .clone()
+                    .unwrap()
+                    .application_1
+                    .as_str(),
+            )),
+            service_id: ServiceId::from(
+                self.config
+                    .test_config
+                    .clone()
+                    .unwrap()
+                    .service_id_1
+                    .as_str(),
+            ),
             service_token: ServiceToken::from(
-                "6705c7d02e9a899d4db405dc1413361611e4250dfd12ec3dcbcea8c3de7cdd29",
+                self.config
+                    .test_config
+                    .clone()
+                    .unwrap()
+                    .service_token_1
+                    .as_str(),
             ),
             metrics: RefCell::new(metrics1),
         };
@@ -173,10 +192,29 @@ impl RootContext for SingletonService {
         .cloned()
         .collect();
         let threescale2 = ThreescaleData {
-            app_id: AppIdentifier::UserKey(UserKey::from("de90b3d58dc5449572d2fdb7ae0af61a")),
-            service_id: ServiceId::from("2555417889374"),
+            app_id: AppIdentifier::UserKey(UserKey::from(
+                self.config
+                    .test_config
+                    .clone()
+                    .unwrap()
+                    .application_2
+                    .as_str(),
+            )),
+            service_id: ServiceId::from(
+                self.config
+                    .test_config
+                    .clone()
+                    .unwrap()
+                    .service_id_2
+                    .as_str(),
+            ),
             service_token: ServiceToken::from(
-                "e1abc8f29e6ba7dfed3fcc9c5399be41f7a881f85fa11df68b93a5d800c3c07a",
+                self.config
+                    .test_config
+                    .clone()
+                    .unwrap()
+                    .service_token_2
+                    .as_str(),
             ),
             metrics: RefCell::new(metrics2),
         };

--- a/singleton-service/src/service/report.rs
+++ b/singleton-service/src/service/report.rs
@@ -1,6 +1,6 @@
-use crate::service::deltas::AppDelta;
 use std::collections::HashMap;
 use std::vec;
+use threescale::structs::AppIdentifier;
 use threescalers::{
     api_call::{ApiCall, Kind},
     application::*,
@@ -12,6 +12,7 @@ use threescalers::{
     usage::Usage,
 };
 
+/// Proxy level representation of the report data for a single service.
 #[derive(Debug)]
 pub struct Report {
     service_id: String,
@@ -19,7 +20,6 @@ pub struct Report {
     usages: HashMap<String, Vec<(String, String)>>,
 }
 
-/// Proxy level representation of the report data for a single service.
 impl Report {
     pub fn service_id(&self) -> &str {
         self.service_id.as_str()
@@ -39,18 +39,17 @@ impl Report {
 /// which is of threescalers Report request type.
 pub fn report<'a>(
     key: &'a str,
-    apps: &'a HashMap<String, AppDelta>,
+    apps: &'a HashMap<AppIdentifier, HashMap<String, u64>>,
 ) -> Result<Report, anyhow::Error> {
     let keys = key.split('_').collect::<Vec<_>>();
     let mut usages_map: HashMap<String, Vec<(String, String)>> = HashMap::new();
     for app in apps {
-        let (app_id, app_deltas): (&String, &AppDelta) = app;
+        let (app_id, app_deltas): (&AppIdentifier, &HashMap<String, u64>) = app;
         let usage = app_deltas
-            .usages
             .iter()
             .map(|(m, v)| (m.to_string(), v.to_string()))
             .collect::<Vec<(String, String)>>();
-        usages_map.insert(app_id.to_string(), usage);
+        usages_map.insert(app_id.as_string(), usage);
     }
     Ok(Report {
         service_id: keys[0].to_string(),

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -46,13 +46,13 @@ pub struct UsageReport {
 }
 
 #[repr(transparent)]
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct AppId(String);
 #[repr(transparent)]
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct AppKey(String);
 #[repr(transparent)]
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct UserKey(String);
 
 impl AsRef<str> for AppId {
@@ -153,7 +153,7 @@ impl<'a> CacheKey {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum AppIdentifier {
     AppId(AppId, Option<AppKey>),
     UserKey(UserKey),


### PR DESCRIPTION
This PR includes,

- cache update operation by performing http calls to 3scale SM API per application. 
- delta store modified to work with app identifier.
- singleton service configuration splitted into several sub configs.
- report and auth call modified to work with app identifier types. (user_key, app_id , app_id+app_key) 