### PR TITLE
update cache key and correct left_hits calculation

### DIFF
--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -101,7 +101,7 @@ impl HttpContext for CacheFilter {
                 }
                 Err(e) => {
                     debug!(
-                        "ctxt {}: failed to map user_key to app_id: {:?}",
+                        "ctxt {}: failed to get app_id for user_key from cache: {:?}",
                         context_id, e
                     );
                     // TODO: avoid multiple calls for identical requests
@@ -213,6 +213,8 @@ impl CacheFilter {
             set_app_id_to_cache(user_key, &app_id)?;
         }
 
+        self.cache_key = CacheKey::from(&service_id, &app_identifier);
+
         for usage in reports {
             state.insert(
                 usage.metric.clone(),
@@ -234,7 +236,7 @@ impl CacheFilter {
                         ),
                         window: Period::from(&usage.period),
                     },
-                    left_hits: usage.current_value,
+                    left_hits: usage.max_value - usage.current_value,
                     max_value: usage.max_value,
                 },
             );


### PR DESCRIPTION
This PR fixes two errors:
- Cache key was not getting updated after retrieving the new `app_id` from the 3scale.
- `left_hits` was earlier set to `current_value` but correct formula is `left_hits = max - current`