### PR TITLE
Initializing 3scale state inside local apisonator deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,15 @@ jobs:
           go version
           go get -u golang.org/x/lint/golint
           go get github.com/stretchr/testify/assert
-
+      
+      - name: Running apisonator
+        run: |
+          docker run -p 6379:6379 -d --name my-redis redis --databases 2
+          docker run -e CONFIG_QUEUES_MASTER_NAME=redis://redis:6379/0 \
+            -e CONFIG_REDIS_PROXY=redis://redis:6379/1 -e CONFIG_INTERNAL_API_USER=root \
+            -e CONFIG_INTERNAL_API_PASSWORD=root -p 3000:3000 -d --link my-redis:redis \
+            quay.io/3scale/apisonator 3scale_backend start
+      
       - name: Building application
         run: make build
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,14 +101,6 @@ jobs:
           go get -u golang.org/x/lint/golint
           go get github.com/stretchr/testify/assert
       
-      - name: Running apisonator
-        run: |
-          docker run -p 6379:6379 -d --name my-redis redis --databases 2
-          docker run -e CONFIG_QUEUES_MASTER_NAME=redis://redis:6379/0 \
-            -e CONFIG_REDIS_PROXY=redis://redis:6379/1 -e CONFIG_INTERNAL_API_USER=root \
-            -e CONFIG_INTERNAL_API_PASSWORD=root -p 3000:3000 -d --link my-redis:redis \
-            quay.io/3scale/apisonator 3scale_backend start
-      
       - name: Building application
         run: make build
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ clean:
 	rm ./deployments/docker-compose/singleton_service.wasm
 	rm ./deployments/docker-compose/cache_filter.wasm
 	rm ./deployments/docker-compose/threescale_wasm_auth.wasm
+	docker rm my-redis -f
+	docker rm apisonator -f
 
 clean-service:
 	@echo "> Cleaning singleton_service build artifacts"
@@ -49,6 +51,10 @@ clean-auth:
 	@echo "> Cleaning threescale_wasm_auth build artifacts"
 	rm ./deployments/docker-compose/threescale_wasm_auth.wasm
 
+clean-apisonator:
+	docker rm my-redis -f
+	docker rm apisonator -f
+
 auth: ## Build threescale_wasm_auth filter. 
 	@echo "> Building threescale_wasm_auth filter"
 	git submodule update --init
@@ -57,22 +63,24 @@ auth: ## Build threescale_wasm_auth filter.
 	make build
 	cp threescale-wasm-auth/target/wasm32-unknown-unknown/$(BUILD)/threescale_wasm_auth.wasm deployments/docker-compose/threescale_wasm_auth.wasm
 
-integration:
+apisonator: ## Runs apisonator and redis container
+	docker run -p 6379:6379 -d --name my-redis redis --databases 2
+	docker run -e CONFIG_QUEUES_MASTER_NAME=redis://redis:6379/0 \
+            -e CONFIG_REDIS_PROXY=redis://redis:6379/1 -e CONFIG_INTERNAL_API_USER=root \
+            -e CONFIG_INTERNAL_API_PASSWORD=root -p 3000:3000 -d --link my-redis:redis \
+            --name apisonator quay.io/3scale/apisonator 3scale_backend start
+
+integration: apisonator
 	@echo "> Starting integration tests"
 	mkdir -p integration-tests/artifacts
 	cp deployments/docker-compose/cache_filter.wasm integration-tests/artifacts/cache_filter.wasm
 	cp deployments/docker-compose/singleton_service.wasm integration-tests/artifacts/singleton_service.wasm
 	cp deployments/docker-compose/threescale_wasm_auth.wasm integration-tests/artifacts/threescale_wasm_auth.wasm
 	go clean -testcache
-	docker run -p 6379:6379 -d --name my-redis redis --databases 2
-	docker run -e CONFIG_QUEUES_MASTER_NAME=redis://redis:6379/0 \
-            -e CONFIG_REDIS_PROXY=redis://redis:6379/1 -e CONFIG_INTERNAL_API_USER=root \
-            -e CONFIG_INTERNAL_API_PASSWORD=root -p 3000:3000 -d --link my-redis:redis \
-            --name apisonator quay.io/3scale/apisonator 3scale_backend start
 	go test -p 1 ./... -v
 	rm -rf integration-tests/artifacts
-	docker rm my-redis
-	docker rm apisonator
+	docker rm my-redis -f
+	docker rm apisonator -f
 
 run:
 	@echo "> Starting services"

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,15 @@ integration:
 	cp deployments/docker-compose/singleton_service.wasm integration-tests/artifacts/singleton_service.wasm
 	cp deployments/docker-compose/threescale_wasm_auth.wasm integration-tests/artifacts/threescale_wasm_auth.wasm
 	go clean -testcache
+	docker run -p 6379:6379 -d --name my-redis redis --databases 2
+	docker run -e CONFIG_QUEUES_MASTER_NAME=redis://redis:6379/0 \
+            -e CONFIG_REDIS_PROXY=redis://redis:6379/1 -e CONFIG_INTERNAL_API_USER=root \
+            -e CONFIG_INTERNAL_API_PASSWORD=root -p 3000:3000 -d --link my-redis:redis \
+            --name apisonator quay.io/3scale/apisonator 3scale_backend start
 	go test -p 1 ./... -v
 	rm -rf integration-tests/artifacts
+	docker rm my-redis
+	docker rm apisonator
 
 run:
 	@echo "> Starting services"

--- a/integration-tests/apisonator.go
+++ b/integration-tests/apisonator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"errors"
 	"bytes"
+	"io"
 )
 
 // These credentials should match those mentioned in the ci.yaml.
@@ -15,7 +16,7 @@ const (
 	PORT = "3000"
 	IP_ADDRESS = "0.0.0.0"
 	INTERNAL_PREFIX = "/internal"
-	INTERNAL_URL = "http://"+INTERNAL_USER+":"+INTERNAL_PASS+"@"+IP_ADDRESS+PORT+INTERNAL_PREFIX
+	INTERNAL_URL = "http://"+INTERNAL_USER+":"+INTERNAL_PASS+"@"+IP_ADDRESS+":"+PORT+INTERNAL_PREFIX
 )
 
 type Period string
@@ -296,7 +297,11 @@ func DeleteUsageLimits(service_id string, plan_id string, metrics *[]Metric) err
 
 func executeHttpRequest(method string, url string, data *[]byte) (*http.Response, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest(method, url, bytes.NewBuffer(*data))
+	var body io.Reader
+	if data != nil {
+		body = bytes.NewBuffer(*data)
+	}
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		fmt.Printf("Error while creating HTTP request: %v", err)
 		return nil, err
@@ -306,5 +311,6 @@ func executeHttpRequest(method string, url string, data *[]byte) (*http.Response
 		fmt.Printf("Error sending the HTTP request: %v", err)
 		return nil, err
 	}
+	defer res.Body.Close()
 	return res, nil
 }

--- a/integration-tests/apisonator.go
+++ b/integration-tests/apisonator.go
@@ -1,0 +1,310 @@
+package main
+
+
+import (
+	"net/http"
+	"fmt"
+	"errors"
+	"bytes"
+)
+
+// These credentials should match those mentioned in the ci.yaml.
+const (
+	INTERNAL_USER = "root"
+	INTERNAL_PASS = "root"
+	PORT = "3000"
+	IP_ADDRESS = "0.0.0.0"
+	INTERNAL_PREFIX = "/internal"
+	INTERNAL_URL = "http://"+INTERNAL_USER+":"+INTERNAL_PASS+"@"+IP_ADDRESS+PORT+INTERNAL_PREFIX
+)
+
+type Period string
+
+const (
+	Minute Period = "minute"
+	Hour Period = "hour"
+	Day Period = "day"
+	Week Period = "week"
+	Month Period = "month"
+	Year Period = "year"
+	Eternity Period = "eternity"
+)
+
+func (p Period) String() string {
+	return string(p)
+}
+
+type UsageLimit struct {
+	period Period
+	value int
+}
+
+type Metric struct {
+	name string
+	id string
+	limits []UsageLimit
+}
+
+func CreateService(service_id string, service_token string) error {
+	client := &http.Client{}
+	// creating service with specified service_id
+	header_data := []byte(fmt.Sprintf(`
+		{ 
+			"service": {
+				"id": "%s",
+				"state": "active"
+			}
+		}`, service_id))
+	req, err := http.NewRequest("POST", INTERNAL_URL+"/services/", bytes.NewBuffer(header_data))
+	if err != nil {
+		fmt.Printf("Error while creating HTTP request: %v", err)
+		return err
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("Error sending the HTTP request: %v", err)
+		return err
+	}
+	if res.StatusCode != 201 {
+		return fmt.Errorf("Failed to create a new service(id: %s)", service_id)
+	}
+
+	// adding a service_token to previously created service
+	header_data = []byte(fmt.Sprintf(`
+		{ 
+			"service_tokens": {
+				"%s": {
+					"service_id": "%s"
+				}
+			}
+		}`, service_token, service_id))
+	url :=  INTERNAL_URL+"/service_tokens/"
+	res, err = executeHttpRequest(http.MethodPost, url, &header_data)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 201 {
+		return fmt.Errorf("Failed to create a service id (%s) and token pair (%s)", service_id, service_token)
+	}
+	return nil
+}
+
+func DeleteService(service_id string, service_token string) error {
+	url :=  INTERNAL_URL+"/services/"+service_id
+	res, err := executeHttpRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("Failed to delete the service(id: %s)", service_id)
+	}
+	header_data := []byte(fmt.Sprintf(`
+		{ 
+			"service_tokens": [{
+				"service_token": %s,
+				"service_id": %s
+			}]
+		}`, service_token, service_id))
+	url =  INTERNAL_URL+"/service_tokens/"
+	res, err = executeHttpRequest(http.MethodDelete, url, &header_data)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("Failed to delete the service id (%s) and token pair (%s)", service_id, service_token)
+	}
+	return nil
+}
+
+// Creating a new application associated with 'service_id', 'app_id' and 'plan_id'
+func AddApplication(service_id string, app_id string, plan_id string) error {
+	header_data := []byte(fmt.Sprintf(`
+		{ 
+			"application": {
+				"service_id": "%s",
+				"id": "%s",
+				"plan_id": "%s"
+				"state": "active"
+			}
+		}`, service_id, app_id, plan_id))
+	url := INTERNAL_URL+"/services/"+service_id+"/applications/"+app_id
+	res, err := executeHttpRequest(http.MethodPost, url, &header_data)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 201 {
+		return fmt.Errorf("Failed to create an application(id: %s)", app_id)
+	}
+	return nil
+}
+
+func DeleteApplication(service_id string, app_id string) error {
+	url :=  INTERNAL_URL+"/services/"+service_id+"/applications"+app_id
+	res, err := executeHttpRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("Failed to delete the application(service_id: %s, app_id: %s)", service_id, app_id)
+	}
+	return nil
+}
+
+// Add key to the application identified by 'service_id' and 'app_id'
+func AddApplicationKey(service_id string, app_id string, key string) error {
+	header_data := []byte(fmt.Sprintf(`
+		{ 
+			"application_key": {
+				"value": "%s"
+			}
+		}`, key))
+	url := INTERNAL_URL+"/services/"+service_id+"/applications/"+app_id+"/keys"
+	res, err := executeHttpRequest(http.MethodPost, url, &header_data)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 201 {
+		return fmt.Errorf("Failed to add an application key(app_id: %s; key: %s)", app_id, key)
+	}
+	return nil
+}
+
+func DeleteApplicationKey(service_id string, app_id string, key string) error {
+	url :=  INTERNAL_URL+"/services/"+service_id+"/applications"+app_id+"/keys/"+key
+	res, err := executeHttpRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("Failed to delete the application key(app_id: %s, key: %s)", app_id, key)
+	}
+	return nil
+}
+
+func AddUserKey(service_id string, app_id string, key string) error {
+	url := INTERNAL_URL+"/services/"+service_id+"/applications/"+app_id+"/key"+key
+	res, err := executeHttpRequest(http.MethodPut, url, nil)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 201 {
+		return fmt.Errorf("Failed to add a user key(app_id: %s)", app_id)
+	}
+	return nil
+}
+
+func DeleteUserKey(service_id string, app_id string, key string) error {
+	url := INTERNAL_URL+"/services/"+service_id+"/applications/key"+key
+	res, err := executeHttpRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("Failed to delete a user key for app(id: %s)", app_id)
+	}
+	return nil
+}
+
+// Add a metrics to a service
+func AddMetrics(service_id string, metrics *[]Metric) error {
+	for _, metric := range *metrics {
+		header_data := []byte(fmt.Sprintf(`
+			{ 
+				"metric": {
+					"service_id": "%s",
+					"id": "%s",
+					"name": "%s"
+				}
+			}`, service_id, metric.id, metric.name))
+		url := INTERNAL_URL+"/services"+service_id+"/metrics/"+metric.id
+		res, err := executeHttpRequest(http.MethodPost, url, &header_data)
+		if err != nil {
+			return err
+		}
+		if res.StatusCode != 201 {
+			return fmt.Errorf("Failed to add a metric to the service(id: %s)", service_id)
+		}
+	}
+	return nil
+}
+
+func DeleteMetrics(service_id string, metrics *[]Metric) error {
+	for _, metric := range *metrics {
+		url :=  INTERNAL_URL+"/services/"+service_id+"/metrics/"+metric.id
+		res, err := executeHttpRequest(http.MethodDelete, url, nil)
+		if err != nil {
+			return err
+		}
+		if res.StatusCode != 200 {
+			return fmt.Errorf("Failed to delete the metric(service_id: %s, metric: %s)", service_id, metric.name)
+		}
+	}
+	return nil
+}
+
+func UpdateUsageLimit(service_id string, plan_id string, metric_id string, limit UsageLimit) error {
+	header_data := []byte(fmt.Sprintf(`
+		{ 
+			"usagelimit": {
+				"%s": "%d"
+			}
+		}`, limit.period.String(), limit.value))
+	url := INTERNAL_URL+"/services"+service_id+"/plans/"+plan_id+"/usagelimits/"+metric_id+"/"+limit.period.String()
+	res, err := executeHttpRequest(http.MethodPut, url, &header_data)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("Failed to update usage limits for a metric(id: %s)", metric_id)
+	}
+	return nil
+}
+
+func UpdateUsageLimits(service_id string, plan_id string, metrics *[]Metric) error {
+	for _, metric := range *metrics {
+		for _, limit := range metric.limits {
+			if err := UpdateUsageLimit(service_id, plan_id, metric.id, limit); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func DeleteUsageLimit(service_id string, plan_id string, metric_id string, period Period) error {
+	url := INTERNAL_URL+"/services"+service_id+"/plans/"+plan_id+"/usagelimits/"+metric_id+"/"+period.String()
+	res, err := executeHttpRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return errors.New("Failed to delete usage limits for a metric")
+	}
+	return nil
+}
+
+func DeleteUsageLimits(service_id string, plan_id string, metrics *[]Metric) error {
+	for _, metric := range *metrics {
+		for _, limit := range metric.limits {
+			if err := DeleteUsageLimit(service_id, plan_id, metric.id, limit.period); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func executeHttpRequest(method string, url string, data *[]byte) (*http.Response, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(*data))
+	if err != nil {
+		fmt.Printf("Error while creating HTTP request: %v", err)
+		return nil, err
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("Error sending the HTTP request: %v", err)
+		return nil, err
+	}
+	return res, nil
+}

--- a/integration-tests/app_id_test.go
+++ b/integration-tests/app_id_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,14 +12,57 @@ import (
 
 type AppCredentialTestSuite struct {
 	suite.Suite
+	service_id string
+	service_token string
+	app_id string
+	app_key string
+	user_key string
+	plan_id string
+	metrics []Metric
 }
 
 func (suite *AppCredentialTestSuite) SetupSuite() {
-	err := StartContainers("./configs/app-id/docker-compose.yaml")
-	time.Sleep(10 * time.Second)
-	if err != nil {
+	if err := StartContainers("./configs/app-id/docker-compose.yaml"); err != nil {
 		fmt.Printf("Error: %v", err)
 		suite.Errorf(err, "Error starting docker-compose: %v")
+	}
+	// Initializing 3scale backend state
+	suite.app_id = "test_app_id"
+	suite.app_key = "test_app_key"
+	suite.user_key = "test_user_key"
+	suite.service_id = "test_service_id"
+	suite.plan_id = "test_plan_id"
+	suite.service_token = "test_service_token"
+	suite.metrics = []Metric {
+		Metric {"hits", "1", []UsageLimit {
+			{ Day, 10000,},
+		}},
+		Metric {"rq", "2", []UsageLimit {
+			{ Month, 10000, },
+		}},
+	}
+	if err := CreateService(suite.service_id, suite.service_token); err != nil {
+		suite.Errorf(err, "Error creating a service: %v")
+		return
+	}
+	if err := AddApplication(suite.service_id, suite.app_id, suite.plan_id); err != nil {
+		suite.Errorf(err, "Error adding an application: %v")
+		return
+	}
+	if err := AddUserKey(suite.service_id, suite.app_id, suite.user_key); err != nil {
+		suite.Errorf(err, "Error adding a user key: %v")
+	}
+	if err := AddApplicationKey(suite.service_id, suite.app_id, suite.app_key); err != nil {
+		suite.Errorf(err, "Error adding application key: %v")
+		return
+	}
+	if err := AddMetrics(suite.service_id, &suite.metrics); err != nil {
+		suite.Errorf(err, "Error adding metrics: %v")
+		return
+	}
+	if err := UpdateUsageLimits(suite.service_id, suite.plan_id, &suite.metrics); err != nil {
+		suite.Errorf(err, "Error updating usage limits: %v")
+		return
 	}
 }
 
@@ -30,6 +72,25 @@ func TestAppCredentialSuite(t *testing.T) {
 }
 
 func (suite *AppCredentialTestSuite) TearDownSuite() {
+	fmt.Println("Cleaning 3scale backend state")
+	if err := DeleteService(suite.service_id, suite.service_token); err != nil {
+		suite.Errorf(err, "Failed to delete service: %v")
+	}
+	if err := DeleteApplication(suite.service_id, suite.app_id); err != nil {
+		suite.Errorf(err, "Failed to delete applications: %v")
+	}
+	if err := DeleteApplicationKey(suite.service_id, suite.app_id, suite.app_key); err != nil {
+		suite.Errorf(err, "Failed to delete Application key: %v")
+	}
+	if err := DeleteUserKey(suite.service_id, suite.app_id, suite.user_key); err != nil {
+		suite.Errorf(err, "Failed to delete Application's user key: %v")
+	}
+	if err := DeleteMetrics(suite.service_id, &suite.metrics); err != nil {
+		suite.Errorf(err, "Failed to delete metrics: %v")
+	}
+	if err := DeleteUsageLimits(suite.service_id, suite.plan_id, &suite.metrics); err != nil {
+		suite.Errorf(err, "Failed to delete usage limits")
+	}
 	fmt.Println("Stopping AppCredentialTestSuite")
 	errStop := StopContainers("./configs/app-id/docker-compose.yaml")
 	if errStop != nil {
@@ -43,8 +104,8 @@ func (suite *AppCredentialTestSuite) TestAppIdSuccess() {
 	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
 	req.Header = http.Header{
 		"Host":      []string{"localhost"},
-		"x-app-id":  []string{"23f118be"},
-		"x-app-key": []string{"44d128988763aee1b0ff0691f9686f7e"},
+		"x-app-id":  []string{suite.app_id},
+		"x-app-key": []string{suite.app_key},
 	}
 	res, errHTTP := client.Do(req)
 	require.Nilf(suite.T(), errHTTP, "Error sending the HTTP request: %v", errHTTP)
@@ -58,8 +119,8 @@ func (suite *AppCredentialTestSuite) TestAppIdForbidden() {
 	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
 	req.Header = http.Header{
 		"Host":      []string{"localhost"},
-		"x-app-id":  []string{"23f118bf"},
-		"x-app-key": []string{"44d128988763aee1b0ff0691f9686f7e"},
+		"x-app-id":  []string{"wrong_app_id"},
+		"x-app-key": []string{suite.app_key},
 	}
 	res, errHTTP := client.Do(req)
 	require.Nilf(suite.T(), errHTTP, "Error sending the HTTP request: %v", errHTTP)
@@ -82,7 +143,7 @@ func (suite *AppCredentialTestSuite) TestUserKeySuccess() {
 
 func (suite *AppCredentialTestSuite) TestUserKeyForbidden() {
 	client := &http.Client{}
-	req, errReq := http.NewRequest("GET", "http://127.0.0.1:9095/", nil)
+	req, errReq := http.NewRequest(http.MethodGet, "http://127.0.0.1:9095/", nil)
 	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
 	q := req.URL.Query()
 	q.Add("api_key", "04fa57ba1e465fb53fddc21ead8a7fc1")

--- a/integration-tests/app_id_test.go
+++ b/integration-tests/app_id_test.go
@@ -104,8 +104,8 @@ func (suite *AppCredentialTestSuite) TestAppIdSuccess() {
 	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
 	req.Header = http.Header{
 		"Host":      []string{"localhost"},
-		"x-app-id":  []string{suite.app_id},
-		"x-app-key": []string{suite.app_key},
+		"x-app-id":  []string{"23f118be"},
+		"x-app-key": []string{"44d128988763aee1b0ff0691f9686f7e"},
 	}
 	res, errHTTP := client.Do(req)
 	require.Nilf(suite.T(), errHTTP, "Error sending the HTTP request: %v", errHTTP)

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -18,8 +18,7 @@ func StartContainers(composePath string) error {
 	cmd := exec.Command("docker-compose", "-f", composePath, "up", "--build", "-d")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		fmt.Printf("Error: %v", err)
 		return err
 	}
@@ -31,8 +30,7 @@ func StopContainers(composePath string) error {
 	cmd := exec.Command("docker-compose", "-f", composePath, "down")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		fmt.Printf("Error: %v", err)
 		return err
 	}

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 )
 
 func main() {
@@ -22,6 +23,7 @@ func StartContainers(composePath string) error {
 		fmt.Printf("Error: %v", err)
 		return err
 	}
+	time.Sleep(10*time.Second)
 	return nil
 }
 


### PR DESCRIPTION
This PR includes:
- Adds a local Apisonator and a required Redis deployment through a docker container and links them to allow communication between them.
- Implements helper functions to initialise and delete 3scale backend states like services, applications, metrics, etc.
- Modifies `app_id_test.go` to take these functionalities into account.
