### PR TITLE
Delta store flush based on memory limit and few other fixes

### DIFF
--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -181,6 +181,7 @@ impl CacheFilter {
                     }
                     updated_cache = true;
                     self.resume_http_request();
+                    break;
                 }
                 Err(UpdateMetricsError::RateLimited) => {
                     info!("ctxt {}: request is rate-limited", self.context_id);

--- a/deployments/docker-compose/envoy.yaml
+++ b/deployments/docker-compose/envoy.yaml
@@ -22,11 +22,11 @@ bootstrap_extensions:
               "timeout": 20
             },
             "delta_store_config": {
-              "capacity": 3,
+              "capacity": 600,
               "periodical_flush": "60s",
               "retry_duration": "30s",
               "await_queue_capacity": 200,
-              "flush_mode": "Periodical"
+              "flush_mode": "ContainerLimit"
             }
           }
       vm_config:

--- a/singleton-service/src/service/deltas.rs
+++ b/singleton-service/src/service/deltas.rs
@@ -1,8 +1,12 @@
 use crate::configuration::delta::{DeltaStoreConfig, FlushMode};
 use chrono::offset::Utc;
 use chrono::DateTime;
+use log::info;
 use std::collections::HashMap;
-use threescale::structs::{AppIdentifier, ThreescaleData};
+use threescale::{
+    structs::{AppIdentifier, ThreescaleData},
+    utils::*,
+};
 
 /// DeltaStore is an in-memory storage built using nested hashmaps to store deltas for different
 /// metrics related to different applications until they gets flushed. Data stored in delta store
@@ -22,7 +26,7 @@ pub struct DeltaStore {
     // Represents the request count. Gets incremented by 1 for each request passing
     // through the proxy. Used together with the capacity attribute to implement a
     // container filling mechansim for cache flush in case of high network traffic scenarios.
-    pub request_count: u64,
+    pub memory_allocated: usize,
 
     // DeltaStoreConfig contains all the configurations related for delta store.
     pub config: DeltaStoreConfig,
@@ -44,19 +48,32 @@ impl DeltaStore {
         &mut self,
         threescale: &ThreescaleData,
     ) -> Result<DeltaStoreState, anyhow::Error> {
+        let delta_increase: usize;
         match self.get_mut_service(
             threescale.service_id.as_ref(),
             threescale.service_token.as_ref(),
         ) {
             Some(service) => match DeltaStore::get_mut_app_delta(&threescale.app_id, service) {
                 Some(app) => {
-                    DeltaStore::update_app_delta(app, threescale);
+                    info!(
+                        "Application {} found for service {}",
+                        &threescale.app_id.as_ref(),
+                        &threescale.service_id.as_ref()
+                    );
+                    delta_increase = DeltaStore::update_app_delta(app, threescale);
                 }
                 None => {
-                    DeltaStore::add_app_delta(service, threescale);
+                    info!(
+                        "No application found for service {}",
+                        &threescale.service_id.as_ref()
+                    );
+                    delta_increase = DeltaStore::add_app_delta(service, threescale);
                 }
             },
             None => {
+                info!("No service and application found for the given key combination");
+                // Current allocation of the services hashmap before new entry.
+                let prev_alloc = self.deltas.capacity();
                 let mut usages: HashMap<AppIdentifier, HashMap<String, u64>> = HashMap::new();
                 usages.insert(
                     threescale.app_id.clone(),
@@ -67,12 +84,35 @@ impl DeltaStore {
                     threescale.service_id.as_ref(),
                     threescale.service_token.as_ref()
                 );
+                // Entry bytes denotes the dynamic heap allocation for the entry.
+                let entry_bytes = delta_key.capacity()
+                    + threescale.app_id.dynamic_allocated_size()
+                    + threescale.metrics.borrow().dynamic_allocated_size();
+                // transitive_alloc denotes the allocations of the inner hashmaps due to
+                // new entry.
+                let transitive_alloc = usages.capacity()
+                    * (std::mem::size_of::<HashMap<String, u64>>()
+                        + std::mem::size_of::<AppIdentifier>())
+                    + threescale.metrics.borrow().capacity()
+                        * (std::mem::size_of::<HashMap<String, u64>>());
                 self.deltas.insert(delta_key, usages);
+                // new_alloc denotes the new allocation of the services hashmap.
+                let new_alloc = self.deltas.capacity();
+                let direct_alloc = (new_alloc - prev_alloc)
+                    * (std::mem::size_of::<String>()
+                        + std::mem::size_of::<HashMap<AppIdentifier, HashMap<String, u64>>>());
+                // Total value of the delta store memory allocation increase is equal to direct_alloc of the
+                // services hashmap + transitive allocation of the nested hashmaps + dynamic allocation of the entry.
+                delta_increase = direct_alloc + transitive_alloc + entry_bytes;
             }
         }
         if self.config.flush_mode != FlushMode::Periodical {
-            self.request_count += 1;
-            if self.request_count == self.config.capacity {
+            info!(
+                "Delta store memory allocation increased by: {}",
+                delta_increase
+            );
+            self.memory_allocated += delta_increase;
+            if self.memory_allocated >= self.config.capacity as usize {
                 Ok(DeltaStoreState::Flush)
             } else {
                 Ok(DeltaStoreState::Ok)
@@ -99,25 +139,53 @@ impl DeltaStore {
         self.deltas.get_mut(&key)
     }
 
-    fn update_app_delta(app_delta: &mut HashMap<String, u64>, threescale: &ThreescaleData) -> bool {
+    fn update_app_delta(
+        app_delta: &mut HashMap<String, u64>,
+        threescale: &ThreescaleData,
+    ) -> usize {
+        let mut entry_bytes: usize = 0;
+        // Current allocation of the metrics hashmap before new entry insertion.
+        let prev_alloc = app_delta.capacity();
         for (metric, value) in threescale.metrics.borrow().iter() {
             if app_delta.contains_key(metric) {
                 *app_delta.get_mut(metric).unwrap() += value;
             } else {
                 app_delta.insert(metric.to_string(), *value);
+                entry_bytes += metric.to_string().dynamic_allocated_size();
             }
         }
-        true
+        // If no new entry, that means updating existing metrics. No difference in memory allocation.
+        if entry_bytes == 0 {
+            0
+        } else {
+            let new_alloc = app_delta.capacity();
+            entry_bytes
+                + (new_alloc - prev_alloc)
+                    * (std::mem::size_of::<String>() + std::mem::size_of::<u64>())
+        }
     }
 
     fn add_app_delta(
         service: &mut HashMap<AppIdentifier, HashMap<String, u64>>,
         threescale: &ThreescaleData,
-    ) -> bool {
+    ) -> usize {
+        // Previous allocation of the application hashmap before new entry.
+        let prev_alloc = service.capacity();
         service.insert(
             threescale.app_id.clone(),
             threescale.metrics.borrow().clone(),
         );
-        true
+        // New allocation of the application hashmap after new entry.
+        let new_alloc = service.capacity();
+        let direct_alloc = (new_alloc - prev_alloc)
+            * (std::mem::size_of::<AppIdentifier>() + std::mem::size_of::<HashMap<String, u64>>());
+        // Transitive allocation of the metrics hashmap.
+        let transitive_alloc = threescale.metrics.borrow().capacity()
+            * (std::mem::size_of::<String>() + std::mem::size_of::<u64>());
+        // Dynamic allocation of the entry.
+        let entry_bytes = threescale.app_id.dynamic_allocated_size()
+            + threescale.metrics.borrow().dynamic_allocated_size();
+        // Total memory allocation as a summation of direct_alloc, entry_bytes and transitive_alloc
+        direct_alloc + entry_bytes + transitive_alloc
     }
 }

--- a/singleton-service/src/service/deltas.rs
+++ b/singleton-service/src/service/deltas.rs
@@ -94,7 +94,7 @@ impl DeltaStore {
                     * (std::mem::size_of::<HashMap<String, u64>>()
                         + std::mem::size_of::<AppIdentifier>())
                     + threescale.metrics.borrow().capacity()
-                        * (std::mem::size_of::<HashMap<String, u64>>());
+                        * (std::mem::size_of::<String>() + std::mem::size_of::<u64>());
                 self.deltas.insert(delta_key, usages);
                 // new_alloc denotes the new allocation of the services hashmap.
                 let new_alloc = self.deltas.capacity();

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -407,7 +407,7 @@ impl SingletonService {
                                     ),
                                     window: Period::from(&usage.period),
                                 },
-                                left_hits: usage.current_value,
+                                left_hits: usage.max_value - usage.current_value,
                                 max_value: usage.max_value,
                             },
                         );

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -69,7 +69,7 @@ pub fn _start() {
             queue_id: None,
             delta_store: DeltaStore {
                 last_update: None,
-                request_count: 0,
+                memory_allocated: 0,
                 deltas: HashMap::new(),
                 config: DeltaStoreConfig::default(),
             },
@@ -319,7 +319,7 @@ impl SingletonService {
     ) -> HashMap<String, HashMap<AppIdentifier, HashMap<String, u64>>> {
         let deltas_cloned = self.delta_store.deltas.clone();
         self.delta_store.deltas.clear();
-        self.delta_store.request_count = 0;
+        self.delta_store.memory_allocated = 0;
         assert!(self.delta_store.deltas.is_empty());
         deltas_cloned
     }

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -8,7 +8,7 @@ use threescalers::response::Period as ResponsePeriod;
 pub type Hierarchy = HashMap<String, Vec<String>>;
 pub type Metrics = RefCell<HashMap<String, u64>>;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub enum Period {
     Minute,
     Hour,
@@ -49,7 +49,7 @@ impl From<&ResponsePeriod> for Period {
 }
 
 #[allow(dead_code)]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct PeriodWindow {
     pub start: Duration,
     pub end: Duration,
@@ -57,7 +57,7 @@ pub struct PeriodWindow {
 }
 
 #[allow(dead_code)]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct UsageReport {
     pub period_window: PeriodWindow,
     pub left_hits: u64,
@@ -199,7 +199,7 @@ impl PartialEq for AppIdentifier {
 }
 
 // Threescale's Application representation for cache
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Application {
     pub app_id: AppIdentifier,
     pub service_id: ServiceId,

--- a/threescale/src/utils.rs
+++ b/threescale/src/utils.rs
@@ -1,6 +1,5 @@
 use crate::proxy::{set_application_to_cache, CacheKey};
-use crate::structs::{AppIdentifier, Application, Hierarchy, Metrics, Period, ThreescaleData};
-use std::collections::HashMap;
+use crate::structs::{Application, Hierarchy, Metrics, Period, ThreescaleData};
 use std::time::Duration;
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -11,13 +10,6 @@ pub enum UpdateMetricsError {
     RateLimited,
     #[error("application set was unsuccessful")]
     CacheUpdateFail,
-}
-
-/// AllocatedSize trait should be implemented for types that have
-/// dynamic memory allocations on the heap and that are taken into
-/// effect for memory allocation.
-pub trait AllocatedSize {
-    fn dynamic_allocated_size(&self) -> usize;
 }
 
 // updates application to reflect consumed quota if not rate-limited
@@ -81,38 +73,5 @@ pub fn add_hierarchy_to_metrics(hierarchy: &Hierarchy, metrics: &mut Metrics) {
                 *metrics.borrow_mut().entry(parent.to_string()).or_insert(0) += *hits;
             }
         }
-    }
-}
-
-/// AllocatedSize impl for String.
-impl AllocatedSize for String {
-    // Returns the dynamically allocated value of a String on the heap.
-    fn dynamic_allocated_size(&self) -> usize {
-        self.capacity()
-    }
-}
-
-/// AllocatedSize impl for AppIdentifier.
-impl AllocatedSize for AppIdentifier {
-    // Returns the dynamically allocated value of a AppIdentifier on the heap.
-    fn dynamic_allocated_size(&self) -> usize {
-        match self {
-            AppIdentifier::AppId(app_id, None) => app_id.as_ref().to_string().capacity(),
-            AppIdentifier::AppId(app_id, Some(app_key)) => {
-                app_id.as_ref().to_string().capacity() + app_key.as_ref().to_string().capacity()
-            }
-            AppIdentifier::UserKey(user_key) => user_key.as_ref().to_string().capacity(),
-        }
-    }
-}
-
-/// AllocatedSize impl for HashMap<String, u64>.
-impl AllocatedSize for HashMap<String, u64> {
-    // Returns the dynamically allocated value of HashMap<String, u64>. Key is considerd
-    // here because u64 has a fixed size.
-    fn dynamic_allocated_size(&self) -> usize {
-        self.iter()
-            .map(|(key, _)| key.dynamic_allocated_size())
-            .sum()
     }
 }


### PR DESCRIPTION
This PR includes,
- Delta store flush based on memory limit
- Singleton usage report left hits issue fixed
- Cache filter for loop issue fixed

**Brief summary about the memory limit calculation** 

We want to calculate the memory allocation for the following hashmap. 

`HashMap<String, HashMap<AppIdentifier, HashMap<String, u64>>>`. This hashmap holds the services, application and metrics according the following structure. 

```sh
- Service
    - Application
        - Metric : Value
```
There can be several scenarios for the delta store update. 

1. When a new service gets added. It will add entries to all the hashmaps.
In this case for the memory increase, following things are considered.

- Dynamic memory allocation of the entries on the heap.
- Hashmap allocation of keys and values for all the hashmaps (service, apps, metrics) (direct alloc + transitive alloc in the PR)

2.  When a new application gets added. It will add entries to the apps hashmap and metrics hashmap.
In this case for the memory increase, following things are considered.

- Dynamic memory allocation of the entries on the heap.
- Hashmap allocation of keys and values for application hashmap and metrics hashmap (direct alloc + transitive alloc in the PR)

3. When a new metric gets added to a already existing application. 
In this case for the memory increase, following things are considered.

- Dynamic memory allocation of the entries on the heap.
- Hashmap allocation of keys and values for metrics hashmap (direct alloc in the PR)

So in all of the cases dynamic memory allocation for the values on the heap + allocation of the hashmap keys and values are considered. (the value we get is an underestimate due to reasons like control bytes but a good approximation for our use case)
