### PR TITLE
Upstream info from previous filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "thiserror",
  "threescale",
  "threescalers",
+ "url",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ auth: ## Build threescale_wasm_auth filter.
 	cd threescale-wasm-auth && \
 	make clean && \
 	make build
-	cp threescale-wasm-auth/compose/wasm/$(BUILD)threescale_wasm_auth.wasm deployments/docker-compose/threescale_wasm_auth.wasm
+	cp threescale-wasm-auth/compose/wasm/threescale_wasm_auth.wasm deployments/docker-compose/threescale_wasm_auth.wasm
 
 apisonator: ## Runs apisonator and redis container
 	docker run -p 6379:6379 -d --name my-redis redis --databases 2

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,11 @@ clean-apisonator:
 
 auth: ## Build threescale_wasm_auth filter. 
 	@echo "> Building threescale_wasm_auth filter"
-	git submodule update --init
+	git submodule foreach git pull origin main
 	cd threescale-wasm-auth && \
 	make clean && \
 	make build
-	cp threescale-wasm-auth/target/wasm32-unknown-unknown/$(BUILD)/threescale_wasm_auth.wasm deployments/docker-compose/threescale_wasm_auth.wasm
+	cp threescale-wasm-auth/compose/wasm/$(BUILD)threescale_wasm_auth.wasm deployments/docker-compose/threescale_wasm_auth.wasm
 
 apisonator: ## Runs apisonator and redis container
 	docker run -p 6379:6379 -d --name my-redis redis --databases 2
@@ -83,7 +83,7 @@ integration: local-services
 	rm -rf integration-tests/artifacts
 	docker-compose -f integration-tests/docker-compose.yaml down
 
-run:
+run: clean-apisonator
 	@echo "> Starting services"
 	docker-compose -f deployments/docker-compose/docker-compose.yaml up --build
 

--- a/cache-filter/Cargo.toml
+++ b/cache-filter/Cargo.toml
@@ -24,3 +24,4 @@ bincode = "1.0"
 threescalers = { git = "https://github.com/3scale-rs/threescalers", branch = "master" }
 serde_xml = "0.9"
 thiserror = "1.0"
+url = { git = "https://github.com/3scale-rs/rust-url", branch = "3scale", features = ["serde"] }

--- a/cache-filter/src/configuration.rs
+++ b/cache-filter/src/configuration.rs
@@ -1,12 +1,8 @@
 use serde::Deserialize;
-use std::time::Duration;
-use threescale::upstream::Upstream;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct FilterConfig {
-    /// Upstream config
-    pub upstream: Upstream,
     /// Behaviour in case of a cache miss and authorize call gets failed.
     pub failure_mode_deny: bool,
     /// Number of retries for setting data to cache
@@ -16,11 +12,6 @@ pub struct FilterConfig {
 impl Default for FilterConfig {
     fn default() -> Self {
         FilterConfig {
-            upstream: Upstream {
-                name: "outbound|443||su1.3scale.net".to_owned(),
-                url: "http://0.0.0.0:3000/".parse().unwrap(),
-                timeout: Duration::from_millis(5000),
-            },
             failure_mode_deny: true,
             max_tries: 5,
         }

--- a/cache-filter/src/utils.rs
+++ b/cache-filter/src/utils.rs
@@ -84,7 +84,7 @@ pub fn do_auth_call<C: HttpContext>(
         .collect::<Vec<_>>();
 
     info!("App : {:?}", apicall);
-    match filter.config.upstream.call(
+    match request_data.upstream.call(
         ctx,
         uri.as_ref(),
         request.method.as_str(),

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -1,3 +1,4 @@
+use crate::upstream::Upstream;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -216,6 +217,7 @@ pub struct ThreescaleData {
     pub service_id: ServiceId,
     pub service_token: ServiceToken,
     pub metrics: Metrics,
+    pub upstream: Upstream,
 }
 
 impl Default for ThreescaleData {
@@ -225,6 +227,11 @@ impl Default for ThreescaleData {
             service_id: ServiceId("".to_owned()),
             service_token: ServiceToken("".to_owned()),
             metrics: RefCell::new(HashMap::new()),
+            upstream: Upstream {
+                name: "".to_owned(),
+                url: url::Url::parse("https://su1.su1.3scale.net/").unwrap(),
+                timeout: Duration::from_millis(1000),
+            },
         }
     }
 }


### PR DESCRIPTION
This PR now makes cache use of upstream info from the previous filter in the chain and passes the same into the MQ to be used by the singleton.