### PR TITLE
Custom logger to have visibility into the filter from the outside

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ apisonator: ## Runs apisonator and redis container
             -e CONFIG_INTERNAL_API_PASSWORD=root -p 3000:3000 -d --link my-redis:redis \
             --name apisonator quay.io/3scale/apisonator 3scale_backend start
 
-local-services:
+local-services: clean-apisonator
 	@echo "> Starting local services for integration tests"
 	docker-compose -f integration-tests/docker-compose.yaml up --build -d
 

--- a/cache-filter/Cargo.toml
+++ b/cache-filter/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["cache filter"]
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+visible_logs = []
+
 [dependencies]
 threescale = { path = "../threescale" }
 serde = { version = "1.0", features = ["derive"] }

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -430,4 +430,17 @@ impl Context for CacheFilter {
             }
         }
     }
+
+    #[cfg(feature = "visible-logs")]
+    fn on_http_response_header(&mut self, _: usize) -> Action {
+        STORED_LOGS.with(|container| {
+            let stored_logs = (*container.borrow()).get(self.context_id);
+            if stored_logs.is_none() {
+                return Action::Continue;
+            }
+            let serialized_logs = serde_json::to_string(stored_logs.unwrap());
+            self.add_http_response_header("filter-logs", serialized_logs);
+            (*container.borrow_mut()).get(self.context_id).clear()
+        })
+    }
 }

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -2,7 +2,7 @@ use crate::{
     configuration::FilterConfig,
     utils::{do_auth_call, in_request_failure, request_process_failure},
 };
-use log::{debug, info, warn};
+use crate::{debug, info, warn};
 use proxy_wasm::{
     traits::{Context, HttpContext},
     types::Action,
@@ -78,7 +78,7 @@ pub enum RequestDataError {
 }
 
 pub struct CacheFilter {
-    pub context_id: u32,
+    pub context_id: usize,
     pub config: FilterConfig,
     pub update_cache_from_singleton: bool,
     pub cache_key: CacheKey,
@@ -91,7 +91,7 @@ impl HttpContext for CacheFilter {
         let mut request_data = match self.get_request_data() {
             Ok(data) => data,
             Err(e) => {
-                debug!("ctxt {}: fetching request data failed: {}", e, context_id);
+                debug!(context: context_id, "fetching request data failed: {}", e);
                 // Send back local response for not providing relevant request data
                 self.send_http_response(401, vec![], None);
                 return Action::Pause;
@@ -110,8 +110,8 @@ impl HttpContext for CacheFilter {
                 }
                 Err(e) => {
                     debug!(
-                        "ctxt {}: failed to get app_id for user_key from cache: {:?}",
-                        context_id, e
+                        context: context_id,
+                        "failed to get app_id for user_key from cache: {:?}", e
                     );
                     // TODO: avoid multiple calls for identical requests
                     return do_auth_call(self, self, &request_data);
@@ -121,18 +121,18 @@ impl HttpContext for CacheFilter {
 
         match get_application_from_cache(&self.cache_key) {
             Ok((mut app, cas)) => {
-                info!("ctxt {}: cache hit", context_id);
+                info!(context: context_id, "cache hit");
 
                 match self.handle_cache_hit(&mut app, cas) {
                     Ok(()) => Action::Continue,
                     Err(e) => {
-                        warn!("ctxt {}: cache hit flow failed: {:#?}", context_id, e);
+                        warn!(context: context_id, "cache hit flow failed: {}", e);
                         in_request_failure(self, self)
                     }
                 }
             }
             Err(e) => {
-                info!("ctxt {}: cache miss: {}", context_id, e);
+                info!(context: context_id, "cache miss: {}", e);
                 // TODO: Avoid multiple calls for same application
                 // saving request data to use when there is response from 3scale
                 // fetching new application state using authorize endpoint
@@ -149,8 +149,9 @@ impl CacheFilter {
         if let Err(e) = self.enqueue_shared_queue(qid, Some(&bincode::serialize(&message).unwrap()))
         {
             warn!(
-                "ctxt {}: enqueuing to message queue failed: {:?}",
-                self.context_id, e
+                context: self.context_id,
+                "enqueuing to message queue failed: {:?}",
+                e
             );
             return false;
         }
@@ -179,10 +180,7 @@ impl CacheFilter {
             match limit_check_and_update_application(&self.req_data, app, app_cas, &current_time) {
                 Ok(()) => {
                     // App is not rate-limited and updated in cache.
-                    info!(
-                        "ctxt {}: request is allowed to pass the filter",
-                        self.context_id
-                    );
+                    info!(context: self.context_id, "request is allowed to pass the filter");
                     if !self.report_to_singleton(queue_id, &current_time) {
                         // TODO: Handle MQ failure here
                         // Update local cache
@@ -193,7 +191,7 @@ impl CacheFilter {
                     break;
                 }
                 Err(UpdateMetricsError::RateLimited) => {
-                    info!("ctxt {}: request is rate-limited", self.context_id);
+                    info!(context: self.context_id, "request is rate-limited");
                     self.send_http_response(429, vec![], Some(b"Request rate-limited.\n"));
                     // no need to retry if already rate-limted
                     rate_limited = true;
@@ -201,8 +199,8 @@ impl CacheFilter {
                 }
                 Err(UpdateMetricsError::CacheUpdateFail) => {
                     info!(
-                        "ctxt {}: try ({} out of {}): failed to set application to cache",
-                        self.context_id,
+                        context: self.context_id,
+                        "try ({} out of {}): failed to set application to cache",
                         (num_try as u64) + 1,
                         max_tries
                     );
@@ -372,8 +370,9 @@ impl CacheFilter {
 impl Context for CacheFilter {
     fn on_http_call_response(&mut self, token_id: u32, _: usize, body_size: usize, _: usize) {
         info!(
-            "ctxt {}: received response from 3scale: token: {}",
-            self.context_id, token_id
+            context: self.context_id,
+            "received response from 3scale: token: {}",
+            token_id
         );
         match self.get_http_call_response_body(0, body_size) {
             Some(bytes) => {
@@ -382,8 +381,9 @@ impl Context for CacheFilter {
                         if response.is_authorized() || response.usage_reports().is_some() {
                             if let Err(e) = self.handle_auth_response(&response) {
                                 warn!(
-                                    "ctxt {}: handling auth response failed: {:?}",
-                                    self.context_id, e
+                                    context: self.context_id,
+                                    "handling auth response failed: {:?}",
+                                    e
                                 );
                                 request_process_failure(self, self)
                             }
@@ -396,12 +396,17 @@ impl Context for CacheFilter {
                         }
                     }
                     Ok(Authorization::Error(auth_error)) => {
-                        info!("authorization error with code: {}", auth_error.code());
+                        info!(
+                            context: self.context_id,
+                            "authorization error with code: {}",
+                            auth_error.code()
+                        );
                         request_process_failure(self, self);
                         return;
                     }
                     Err(e) => {
                         info!(
+                            context: self.context_id,
                             "parsing response from 3scale failed: {:#?} with token: {}",
                             e, token_id
                         );
@@ -411,12 +416,16 @@ impl Context for CacheFilter {
                 }
 
                 info!(
+                    context: self.context_id,
                     "data received and parsed from callout with token :{}",
                     token_id
                 );
             }
             None => {
-                info!("Found nothing in the response with token: {}", token_id);
+                info!(
+                    context: self.context_id,
+                    "Found nothing in the response with token: {}",
+                    token_id);
                 request_process_failure(self, self);
             }
         }

--- a/cache-filter/src/filter/root.rs
+++ b/cache-filter/src/filter/root.rs
@@ -14,14 +14,14 @@ pub fn _start() {
     }));
     proxy_wasm::set_root_context(|context_id| -> Box<dyn RootContext> {
         Box::new(CacheFilterRoot {
-            context_id,
+            context_id: (context_id as usize),
             config: FilterConfig::default(),
         })
     });
 }
 
 struct CacheFilterRoot {
-    context_id: u32,
+    context_id: usize,
     config: FilterConfig,
 }
 

--- a/cache-filter/src/lib.rs
+++ b/cache-filter/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all, clippy::cargo)]
 mod configuration;
 mod filter;
+mod log;
 mod utils;

--- a/cache-filter/src/log.rs
+++ b/cache-filter/src/log.rs
@@ -2,52 +2,77 @@ use proxy_wasm::types::LogLevel;
 
 #[macro_export(local_inner_macros)]
 macro_rules! log {
-    (context: $context:expr, $lvl:expr, $($arg:tt)+) => ({
+    ($context:expr, $lvl:expr, $($arg:tt)+) => ({
         $crate::log::__custom_log($context, std::format_args!($($arg)+), $lvl)
     })
 }
 
 #[macro_export(local_inner_macros)]
 macro_rules! debug {
-    (context: $context:expr, $($arg:tt)+) => (
-        log!(context: $context, proxy_wasm::types::LogLevel::Debug, $($arg)+)
+    ($context:expr, $($arg:tt)+) => (
+        log!($context, proxy_wasm::types::LogLevel::Debug, $($arg)+)
     )
 }
 
 #[macro_export(local_inner_macros)]
 macro_rules! info {
-    (context: $context:expr, $($arg:tt)+) => (
-        log!(context: $context, proxy_wasm::types::LogLevel::Info, $($arg)+)
+    ($context:expr, $($arg:tt)+) => (
+        log!($context, proxy_wasm::types::LogLevel::Info, $($arg)+)
     )
 }
 
 #[macro_export(local_inner_macros)]
 macro_rules! warn {
-    (context: $context:expr, $($arg:tt)+) => (
-        log!(context: $context, proxy_wasm::types::LogLevel::Warn, $($arg)+)
+    ($context:expr, $($arg:tt)+) => (
+        log!($context, proxy_wasm::types::LogLevel::Warn, $($arg)+)
     )
 }
 
 #[cfg(feature = "visible_logs")]
-mod visible_logs {
+pub mod visible_logs {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
+    const LOGS_HEADER: &str = "filter-logs";
+
     thread_local! {
-        static STORED_LOGS: RefCell<HashMap<usize,Vec<String>>> = RefCell::new(HashMap::new());
+        pub static STORED_LOGS: RefCell<HashMap<u32,Vec<String>>> = RefCell::new(HashMap::new());
     }
 
-    pub fn store_logs(context: usize, message: &str) {
-        STORED_LOGS.with(|container| {
-            let mut stored_logs = container.borrow_mut();
-            (*stored_logs)
-                .entry(context)
-                .or_insert_with(|| vec![message.to_string()]);
+    pub fn store_logs(context: u32, message: &str) {
+        STORED_LOGS.with(|refcell| {
+            let mut inner_map = refcell.borrow_mut();
+            let stored_logs = (*inner_map).entry(context).or_insert_with(Vec::new);
+            (*stored_logs).push(message.to_string());
         });
+    }
+
+    pub fn get_logs_header_pair(context_id: u32) -> (String, String) {
+        STORED_LOGS.with(|refcell| {
+            let mut inner_map = refcell.borrow_mut();
+            let header_key = LOGS_HEADER.to_string();
+            let stored_logs = (*inner_map).get(&context_id);
+            if stored_logs.is_none() {
+                return (
+                    header_key,
+                    "couldn't find logs in the hashmap for this context".to_string(),
+                );
+            }
+
+            let serialized_logs = serde_json::to_string(stored_logs.unwrap());
+            if let Err(e) = serialized_logs {
+                return (header_key, format!("failed to serialize logs: {:?}", e));
+            }
+
+            // clear logs for the current context.
+            (*inner_map).get_mut(&context_id).unwrap().clear();
+
+            (header_key, serialized_logs.unwrap())
+        })
     }
 }
 
-pub fn __custom_log(context: usize, args: std::fmt::Arguments, level: LogLevel) {
+pub fn __custom_log(context: u32, args: std::fmt::Arguments, level: LogLevel) {
     let message = format!("context# {}: {}", context, args.to_string());
     #[cfg(feature = "visible_logs")]
     visible_logs::store_logs(context, &message);

--- a/cache-filter/src/log.rs
+++ b/cache-filter/src/log.rs
@@ -1,0 +1,55 @@
+use proxy_wasm::types::LogLevel;
+
+#[macro_export(local_inner_macros)]
+macro_rules! log {
+    (context: $context:expr, $lvl:expr, $($arg:tt)+) => ({
+        $crate::log::__custom_log($context, std::format_args!($($arg)+), $lvl)
+    })
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! debug {
+    (context: $context:expr, $($arg:tt)+) => (
+        log!(context: $context, proxy_wasm::types::LogLevel::Debug, $($arg)+)
+    )
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! info {
+    (context: $context:expr, $($arg:tt)+) => (
+        log!(context: $context, proxy_wasm::types::LogLevel::Info, $($arg)+)
+    )
+}
+
+#[macro_export(local_inner_macros)]
+macro_rules! warn {
+    (context: $context:expr, $($arg:tt)+) => (
+        log!(context: $context, proxy_wasm::types::LogLevel::Warn, $($arg)+)
+    )
+}
+
+#[cfg(feature = "visible_logs")]
+mod visible_logs {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    thread_local! {
+        static STORED_LOGS: RefCell<HashMap<usize,Vec<String>>> = RefCell::new(HashMap::new());
+    }
+
+    pub fn store_logs(context: usize, message: &str) {
+        STORED_LOGS.with(|container| {
+            let mut stored_logs = container.borrow_mut();
+            (*stored_logs)
+                .entry(context)
+                .or_insert_with(|| vec![message.to_string()]);
+        });
+    }
+}
+
+pub fn __custom_log(context: usize, args: std::fmt::Arguments, level: LogLevel) {
+    let message = format!("context# {}: {}", context, args.to_string());
+    #[cfg(feature = "visible_logs")]
+    visible_logs::store_logs(context, &message);
+    proxy_wasm::hostcalls::log(level, &message).unwrap();
+}

--- a/cache-filter/src/utils.rs
+++ b/cache-filter/src/utils.rs
@@ -16,7 +16,19 @@ use threescalers::{
 // Helper function to handle failure when request headers are recieved
 pub fn in_request_failure<C: HttpContext>(ctx: &C, filter: &CacheFilter) -> Action {
     if filter.config.failure_mode_deny {
-        ctx.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
+        if cfg!(feature = "visible_logs") {
+            #[cfg(feature = "visible_logs")]
+            {
+                let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
+                ctx.send_http_response(
+                    403,
+                    vec![(key.as_ref(), val.as_ref())],
+                    Some(b"Access forbidden.\n"),
+                );
+            }
+        } else {
+            ctx.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
+        }
         return Action::Pause;
     }
     Action::Continue
@@ -25,7 +37,19 @@ pub fn in_request_failure<C: HttpContext>(ctx: &C, filter: &CacheFilter) -> Acti
 // Helper function to handle failure during processing
 pub fn request_process_failure<C: HttpContext>(ctx: &C, filter: &CacheFilter) {
     if filter.config.failure_mode_deny {
-        ctx.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
+        if cfg!(feature = "visible_logs") {
+            #[cfg(feature = "visible_logs")]
+            {
+                let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
+                ctx.send_http_response(
+                    403,
+                    vec![(key.as_ref(), val.as_ref())],
+                    Some(b"Access forbidden.\n"),
+                );
+            }
+        } else {
+            ctx.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
+        }
     }
     ctx.resume_http_request();
 }


### PR DESCRIPTION
This PR allows integration testing to have more visibility into what is happening inside the cache filter by exposing logs into the response headers. Logs are stored only when the cache is built with `visible-logs` feature flag.