### PR TITLE
Add job for build and clippy with no feature included 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
             # MSRV
           - 1.52.1
         experimental: [false]
-        cargo_flags: [--all-features]
+        cargo_flags: ['',--all-features]
         include:
           # Stop breakages in nightly to fail the workflow
           - rust: nightly

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -28,3 +28,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets --all-features -- -D warnings
+
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets -- -D warnings


### PR DESCRIPTION
Since now we have features that can be removed, we need to run CI checks when no feature is allowed to be built into the modules. 