### PR TITLE
Easing integration tests using a backend state manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean-apisonator:
 
 auth: ## Build threescale_wasm_auth filter. 
 	@echo "> Building threescale_wasm_auth filter"
-	git submodule foreach git pull origin main
+	git submodule update --init
 	cd threescale-wasm-auth && \
 	make clean && \
 	make build

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean-apisonator:
 
 auth: ## Build threescale_wasm_auth filter. 
 	@echo "> Building threescale_wasm_auth filter"
-	git submodule update --init
+	git submodule foreach git pull origin main
 	cd threescale-wasm-auth && \
 	make clean && \
 	make build

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -95,12 +95,9 @@ impl HttpContext for CacheFilter {
 
                 // Send back local response for not providing relevant request data
                 if cfg!(feature = "visible_logs") {
-                    #[cfg(feature = "visible_logs")]
-                    {
-                        let (key, val) =
-                            crate::log::visible_logs::get_logs_header_pair(self.context_id);
-                        self.send_http_response(401, vec![(key.as_ref(), val.as_ref())], None);
-                    }
+                    let (key, val) =
+                        crate::log::visible_logs::get_logs_header_pair(self.context_id);
+                    self.send_http_response(401, vec![(key.as_ref(), val.as_ref())], None);
                 } else {
                     self.send_http_response(401, vec![], None);
                 }
@@ -401,16 +398,13 @@ impl Context for CacheFilter {
                                 request_process_failure(self, self)
                             }
                         } else if cfg!(feature = "visible_logs") {
-                            #[cfg(feature = "visible_logs")]
-                            {
-                                let (key, val) =
-                                    crate::log::visible_logs::get_logs_header_pair(self.context_id);
-                                self.send_http_response(
-                                    403,
-                                    vec![(key.as_ref(), val.as_ref())],
-                                    Some(response.reason().unwrap().as_bytes()),
-                                );
-                            }
+                            let (key, val) =
+                                crate::log::visible_logs::get_logs_header_pair(self.context_id);
+                            self.send_http_response(
+                                403,
+                                vec![(key.as_ref(), val.as_ref())],
+                                Some(response.reason().unwrap().as_bytes()),
+                            );
                         } else {
                             self.send_http_response(
                                 403,

--- a/cache-filter/src/log.rs
+++ b/cache-filter/src/log.rs
@@ -78,3 +78,14 @@ pub fn __custom_log(context: u32, args: std::fmt::Arguments, level: LogLevel) {
     visible_logs::store_logs(context, &message);
     proxy_wasm::hostcalls::log(level, &message).unwrap();
 }
+
+// This is required for clean use of cfg! with visible_logs module
+#[cfg(not(feature = "visible_logs"))]
+pub mod visible_logs {
+    pub fn get_logs_header_pair(_: u32) -> (String, String) {
+        (
+            "enable visible_logs".to_string(),
+            "using cargo flags first".to_string(),
+        )
+    }
+}

--- a/cache-filter/src/utils.rs
+++ b/cache-filter/src/utils.rs
@@ -17,15 +17,12 @@ use threescalers::{
 pub fn in_request_failure<C: HttpContext>(ctx: &C, filter: &CacheFilter) -> Action {
     if filter.config.failure_mode_deny {
         if cfg!(feature = "visible_logs") {
-            #[cfg(feature = "visible_logs")]
-            {
-                let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
-                ctx.send_http_response(
-                    403,
-                    vec![(key.as_ref(), val.as_ref())],
-                    Some(b"Access forbidden.\n"),
-                );
-            }
+            let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
+            ctx.send_http_response(
+                403,
+                vec![(key.as_ref(), val.as_ref())],
+                Some(b"Access forbidden.\n"),
+            );
         } else {
             ctx.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
         }
@@ -38,15 +35,12 @@ pub fn in_request_failure<C: HttpContext>(ctx: &C, filter: &CacheFilter) -> Acti
 pub fn request_process_failure<C: HttpContext>(ctx: &C, filter: &CacheFilter) {
     if filter.config.failure_mode_deny {
         if cfg!(feature = "visible_logs") {
-            #[cfg(feature = "visible_logs")]
-            {
-                let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
-                ctx.send_http_response(
-                    403,
-                    vec![(key.as_ref(), val.as_ref())],
-                    Some(b"Access forbidden.\n"),
-                );
-            }
+            let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
+            ctx.send_http_response(
+                403,
+                vec![(key.as_ref(), val.as_ref())],
+                Some(b"Access forbidden.\n"),
+            );
         } else {
             ctx.send_http_response(403, vec![], Some(b"Access forbidden.\n"));
         }

--- a/integration-tests/apisonator.go
+++ b/integration-tests/apisonator.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 )
 
-
 // BackendState represents the Apisonator internal state
 type BackendState struct {
 	name   string

--- a/integration-tests/app_id_test.go
+++ b/integration-tests/app_id_test.go
@@ -12,6 +12,7 @@ import (
 
 type AppCredentialTestSuite struct {
 	suite.Suite
+	backend      Backend
 	ServiceID    string
 	ServiceToken string
 	AppID        string
@@ -39,22 +40,22 @@ func (suite *AppCredentialTestSuite) SetupSuite() {
 			{Month, 10000},
 		}},
 	}
-	serviceErr := CreateService(suite.ServiceID, suite.ServiceToken)
+	serviceErr := suite.backend.CreateService(suite.ServiceID, suite.ServiceToken)
 	require.Nilf(suite.T(), serviceErr, "Error: %v", serviceErr)
 
-	appErr := AddApplication(suite.ServiceID, suite.AppID, suite.PlanID)
+	appErr := suite.backend.AddApplication(suite.ServiceID, suite.AppID, suite.PlanID)
 	require.Nilf(suite.T(), appErr, "Error: %v", appErr)
 
-	userErr := AddUserKey(suite.ServiceID, suite.AppID, suite.UserKey)
+	userErr := suite.backend.AddUserKey(suite.ServiceID, suite.AppID, suite.UserKey)
 	require.Nilf(suite.T(), userErr, "Error: %v", userErr)
 
-	appKeyErr := AddApplicationKey(suite.ServiceID, suite.AppID, suite.AppKey)
+	appKeyErr := suite.backend.AddApplicationKey(suite.ServiceID, suite.AppID, suite.AppKey)
 	require.Nilf(suite.T(), appKeyErr, "Error: %v", appKeyErr)
 
-	metricsErr := AddMetrics(suite.ServiceID, &suite.metrics)
+	metricsErr := suite.backend.AddMetrics(suite.ServiceID, &suite.metrics)
 	require.Nilf(suite.T(), metricsErr, "Error: %v", metricsErr)
 
-	usageErr := UpdateUsageLimits(suite.ServiceID, suite.PlanID, &suite.metrics)
+	usageErr := suite.backend.UpdateUsageLimits(suite.ServiceID, suite.PlanID, &suite.metrics)
 	require.Nilf(suite.T(), usageErr, "Error: %v", usageErr)
 
 }
@@ -70,23 +71,8 @@ func (suite *AppCredentialTestSuite) TearDownSuite() {
 		fmt.Printf("Error stoping docker: %v", err)
 	}
 	fmt.Println("Cleaning 3scale backend state")
-	serviceErr := DeleteService(suite.ServiceID, suite.ServiceToken)
-	require.Nilf(suite.T(), serviceErr, "Error: %v", serviceErr)
-
-	appKeyErr := DeleteApplicationKey(suite.ServiceID, suite.AppID, suite.AppKey)
-	require.Nilf(suite.T(), appKeyErr, "Error: %v", appKeyErr)
-
-	userKeyErr := DeleteUserKey(suite.ServiceID, suite.AppID, suite.UserKey)
-	require.Nilf(suite.T(), userKeyErr, "Error: %v", userKeyErr)
-
-	appErr := DeleteApplication(suite.ServiceID, suite.AppID)
-	require.Nilf(suite.T(), appErr, "Error: %v", appErr)
-
-	metricsErr := DeleteMetrics(suite.ServiceID, &suite.metrics)
-	require.Nilf(suite.T(), metricsErr, "Error: %v", metricsErr)
-
-	usageErr := DeleteUsageLimits(suite.ServiceID, suite.PlanID, &suite.metrics)
-	require.Nilf(suite.T(), usageErr, "Error: %v", usageErr)
+	flushErr := suite.backend.Flush()
+	require.Nilf(suite.T(), flushErr, "Error: %v", flushErr)
 }
 
 func (suite *AppCredentialTestSuite) TestAppIdSuccess() {
@@ -147,11 +133,11 @@ func (suite *AppCredentialTestSuite) TestUserKeyForbidden() {
 
 func (suite *AppCredentialTestSuite) TestUnlimitedUserKey() {
 	// Add a new unlimited app
-	if err := AddApplication(suite.ServiceID, "unlimited_app_id", suite.PlanID); err != nil {
+	if err := suite.backend.AddApplication(suite.ServiceID, "unlimited_app_id", suite.PlanID); err != nil {
 		suite.Errorf(err, "Error adding an application: %v")
 		return
 	}
-	if err := AddUserKey(suite.ServiceID, "unlimited_app_id", suite.UserKey); err != nil {
+	if err := suite.backend.AddUserKey(suite.ServiceID, "unlimited_app_id", suite.UserKey); err != nil {
 		suite.Errorf(err, "Error adding a user key: %v")
 	}
 	client := &http.Client{}
@@ -165,17 +151,17 @@ func (suite *AppCredentialTestSuite) TestUnlimitedUserKey() {
 	fmt.Printf("Response: %v", res)
 	assert.Equal(suite.T(), 200, res.StatusCode, "Invalid http response code for user_key unlimited test: %v", res.StatusCode)
 
-	if err := DeleteUserKey(suite.ServiceID, "unlimited_app_id", suite.UserKey); err != nil {
+	if err := suite.backend.Pop(); err != nil {
 		suite.Errorf(err, "Failed to delete Application's user key: %v")
 	}
-	if err := DeleteApplication(suite.ServiceID, "unlimited_app_id"); err != nil {
+	if err := suite.backend.Pop(); err != nil {
 		suite.Errorf(err, "Failed to delete applications: %v")
 	}
 }
 
 func (suite *AppCredentialTestSuite) TestUnlimitedAppId() {
 	// Add a new unlimited app
-	if err := AddApplication(suite.ServiceID, "unlimited_app_id", suite.PlanID); err != nil {
+	if err := suite.backend.AddApplication(suite.ServiceID, "unlimited_app_id", suite.PlanID); err != nil {
 		suite.Errorf(err, "Error adding an application: %v")
 		return
 	}
@@ -192,7 +178,7 @@ func (suite *AppCredentialTestSuite) TestUnlimitedAppId() {
 	fmt.Printf("Response: %v", res)
 	assert.Equal(suite.T(), 200, res.StatusCode, "Invalid http response code for appId unlimited test: %d", res.StatusCode)
 
-	if err := DeleteApplication(suite.ServiceID, "unlimited_app_id"); err != nil {
+	if err := suite.backend.Pop(); err != nil {
 		suite.Errorf(err, "Failed to delete applications: %v")
 	}
 }

--- a/integration-tests/app_id_test.go
+++ b/integration-tests/app_id_test.go
@@ -40,22 +40,22 @@ func (suite *AppCredentialTestSuite) SetupSuite() {
 			{Month, 10000},
 		}},
 	}
-	serviceErr := suite.backend.CreateService(suite.ServiceID, suite.ServiceToken)
+	serviceErr := suite.backend.Push("service", []interface{}{suite.ServiceID, suite.ServiceToken})
 	require.Nilf(suite.T(), serviceErr, "Error: %v", serviceErr)
 
-	appErr := suite.backend.AddApplication(suite.ServiceID, suite.AppID, suite.PlanID)
+	appErr := suite.backend.Push("app", []interface{}{suite.ServiceID, suite.AppID, suite.PlanID})
 	require.Nilf(suite.T(), appErr, "Error: %v", appErr)
 
-	userErr := suite.backend.AddUserKey(suite.ServiceID, suite.AppID, suite.UserKey)
+	userErr := suite.backend.Push("user_key", []interface{}{suite.ServiceID, suite.AppID, suite.UserKey})
 	require.Nilf(suite.T(), userErr, "Error: %v", userErr)
 
-	appKeyErr := suite.backend.AddApplicationKey(suite.ServiceID, suite.AppID, suite.AppKey)
+	appKeyErr := suite.backend.Push("app_key", []interface{}{suite.ServiceID, suite.AppID, suite.AppKey})
 	require.Nilf(suite.T(), appKeyErr, "Error: %v", appKeyErr)
 
-	metricsErr := suite.backend.AddMetrics(suite.ServiceID, &suite.metrics)
+	metricsErr := suite.backend.Push("metrics", []interface{}{suite.ServiceID, &suite.metrics})
 	require.Nilf(suite.T(), metricsErr, "Error: %v", metricsErr)
 
-	usageErr := suite.backend.UpdateUsageLimits(suite.ServiceID, suite.PlanID, &suite.metrics)
+	usageErr := suite.backend.Push("usages", []interface{}{suite.ServiceID, suite.PlanID, &suite.metrics})
 	require.Nilf(suite.T(), usageErr, "Error: %v", usageErr)
 
 }
@@ -133,12 +133,11 @@ func (suite *AppCredentialTestSuite) TestUserKeyForbidden() {
 
 func (suite *AppCredentialTestSuite) TestUnlimitedUserKey() {
 	// Add a new unlimited app
-	if err := suite.backend.AddApplication(suite.ServiceID, "unlimited_app_id", suite.PlanID); err != nil {
-		suite.Errorf(err, "Error adding an application: %v")
-		return
+	if err := suite.backend.Push("app", []interface{}{suite.ServiceID, "unlimited_app_id", suite.PlanID}); err != nil {
+		require.Nilf(suite.T(), err, "Error adding an application: %v", err)
 	}
-	if err := suite.backend.AddUserKey(suite.ServiceID, "unlimited_app_id", suite.UserKey); err != nil {
-		suite.Errorf(err, "Error adding a user key: %v")
+	if err := suite.backend.Push("user_key", []interface{}{suite.ServiceID, "unlimited_app_id", suite.UserKey}); err != nil {
+		require.Nilf(suite.T(), err, "Error adding a user key: %v", err)
 	}
 	client := &http.Client{}
 	req, errReq := http.NewRequest("GET", "http://127.0.0.1:9095/", nil)
@@ -152,18 +151,17 @@ func (suite *AppCredentialTestSuite) TestUnlimitedUserKey() {
 	assert.Equal(suite.T(), 200, res.StatusCode, "Invalid http response code for user_key unlimited test: %v", res.StatusCode)
 
 	if err := suite.backend.Pop(); err != nil {
-		suite.Errorf(err, "Failed to delete Application's user key: %v")
+		require.Nilf(suite.T(), err, "Failed to delete Application's user key: %v", err)
 	}
 	if err := suite.backend.Pop(); err != nil {
-		suite.Errorf(err, "Failed to delete applications: %v")
+		require.Nilf(suite.T(), err, "Failed to delete applications: %v", err)
 	}
 }
 
 func (suite *AppCredentialTestSuite) TestUnlimitedAppId() {
 	// Add a new unlimited app
-	if err := suite.backend.AddApplication(suite.ServiceID, "unlimited_app_id", suite.PlanID); err != nil {
-		suite.Errorf(err, "Error adding an application: %v")
-		return
+	if err := suite.backend.Push("app", []interface{}{suite.ServiceID, "unlimited_app_id", suite.PlanID}); err != nil {
+		require.Nilf(suite.T(), err, "Error adding an application: %v", err)
 	}
 
 	client := &http.Client{}
@@ -179,6 +177,6 @@ func (suite *AppCredentialTestSuite) TestUnlimitedAppId() {
 	assert.Equal(suite.T(), 200, res.StatusCode, "Invalid http response code for appId unlimited test: %d", res.StatusCode)
 
 	if err := suite.backend.Pop(); err != nil {
-		suite.Errorf(err, "Failed to delete applications: %v")
+		require.Nilf(suite.T(), err, "Failed to delete applications: %v", err)
 	}
 }


### PR DESCRIPTION
This PR adds a struct to easily manager backend (Apisonator) state with functions:
- `Pop()`: to pop the last state added.
- `Flush()`: to clear off every state added till then. No need to write Delete* functions anymore 😄 
- `Push()`: to add a new state.

Plus, did some mopping in the cache side as well.