### PR TITLE
Singleton integration tests 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/3scale-labs/gsoc-wasm-filters/integration-tests
 go 1.16
 
 require (
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/integration-tests/apisonator.go
+++ b/integration-tests/apisonator.go
@@ -374,9 +374,6 @@ func executeHTTPRequest(method string, url string, data *[]byte) (*http.Response
 
 // Push adds a new state
 func (backend *Backend) Push(stateName string, params []interface{}) error {
-	// defer func() {
-	// 	backend.states = append(backend.states, BackendState{stateName, params})
-	// }()
 	var err error
 	switch stateName {
 	case "service":

--- a/integration-tests/apisonator.go
+++ b/integration-tests/apisonator.go
@@ -374,25 +374,28 @@ func executeHTTPRequest(method string, url string, data *[]byte) (*http.Response
 
 // Push adds a new state
 func (backend *Backend) Push(stateName string, params []interface{}) error {
-	defer func() {
-		backend.states = append(backend.states, BackendState{stateName, params})
-	}()
-
+	// defer func() {
+	// 	backend.states = append(backend.states, BackendState{stateName, params})
+	// }()
+	var err error
 	switch stateName {
 	case "service":
-		return CreateService(params[0].(string), params[1].(string))
+		err = CreateService(params[0].(string), params[1].(string))
 	case "app":
-		return AddApplication(params[0].(string), params[1].(string), params[2].(string))
+		err = AddApplication(params[0].(string), params[1].(string), params[2].(string))
 	case "app_key":
-		return AddApplicationKey(params[0].(string), params[1].(string), params[2].(string))
+		err = AddApplicationKey(params[0].(string), params[1].(string), params[2].(string))
 	case "user_key":
-		return AddUserKey(params[0].(string), params[1].(string), params[2].(string))
+		err = AddUserKey(params[0].(string), params[1].(string), params[2].(string))
 	case "metrics":
-		return AddMetrics(params[0].(string), params[1].(*[]Metric))
+		err = AddMetrics(params[0].(string), params[1].(*[]Metric))
 	case "usage_limits":
-		return UpdateUsageLimits(params[0].(string), params[1].(string), params[2].(*[]Metric))
+		err = UpdateUsageLimits(params[0].(string), params[1].(string), params[2].(*[]Metric))
 	}
-
+	if err != nil {
+		return err
+	}
+	backend.states = append(backend.states, BackendState{stateName, params})
 	return nil
 }
 
@@ -402,24 +405,26 @@ func (backend *Backend) Pop() error {
 		state := backend.states[len(backend.states)-1]
 		params := state.params
 
-		defer func() {
-			backend.states = backend.states[:len(backend.states)-1]
-		}()
-
+		var err error
 		switch state.name {
 		case "service":
-			return DeleteService(params[0].(string), params[1].(string))
+			err = DeleteService(params[0].(string), params[1].(string))
 		case "app":
-			return DeleteApplication(params[0].(string), params[1].(string))
+			err = DeleteApplication(params[0].(string), params[1].(string))
 		case "app_key":
-			return DeleteApplicationKey(params[0].(string), params[1].(string), params[2].(string))
+			err = DeleteApplicationKey(params[0].(string), params[1].(string), params[2].(string))
 		case "user_key":
-			return DeleteUserKey(params[0].(string), params[1].(string), params[2].(string))
+			err = DeleteUserKey(params[0].(string), params[1].(string), params[2].(string))
 		case "metrics":
-			return DeleteMetrics(params[0].(string), params[1].(*[]Metric))
+			err = DeleteMetrics(params[0].(string), params[1].(*[]Metric))
 		case "usage_limits":
-			return DeleteUsageLimits(params[0].(string), params[1].(string), params[2].(*[]Metric))
+			err = DeleteUsageLimits(params[0].(string), params[1].(string), params[2].(*[]Metric))
 		}
+		if err != nil {
+			return err
+		}
+		backend.states = backend.states[:len(backend.states)-1]
+		return nil
 	}
 	return nil
 }

--- a/integration-tests/app_id_test.go
+++ b/integration-tests/app_id_test.go
@@ -101,6 +101,14 @@ func (suite *AppCredentialTestSuite) SetupSuite() {
 
 	err := StartProxy("./", "./temp.yaml")
 	require.Nilf(suite.T(), err, "Error starting proxy: %v", err)
+	require.Eventually(suite.T(), func() bool {
+		res, err := http.Get("http://localhost:9095/")
+		if err != nil {
+			return false
+		}
+		defer res.Body.Close()
+		return true
+	}, 15*time.Second, 1*time.Second, "Envoy has not started")
 
 }
 

--- a/integration-tests/app_id_test.go
+++ b/integration-tests/app_id_test.go
@@ -55,7 +55,7 @@ func (suite *AppCredentialTestSuite) SetupSuite() {
 	metricsErr := suite.backend.Push("metrics", []interface{}{suite.ServiceID, &suite.metrics})
 	require.Nilf(suite.T(), metricsErr, "Error: %v", metricsErr)
 
-	usageErr := suite.backend.Push("usages", []interface{}{suite.ServiceID, suite.PlanID, &suite.metrics})
+	usageErr := suite.backend.Push("usage_limits", []interface{}{suite.ServiceID, suite.PlanID, &suite.metrics})
 	require.Nilf(suite.T(), usageErr, "Error: %v", usageErr)
 
 }

--- a/integration-tests/config_template.yaml
+++ b/integration-tests/config_template.yaml
@@ -100,8 +100,8 @@ static_resources:
                       },
                       "services": [
                         {
-                          "id": "{{or .ServiceID "\"test-service-id\""}}",
-                          "token": "{{or .ServiceToken "\"test-service-token\""}}",
+                          "id": "{{ .ServiceID }}",
+                          "token": "{{ .ServiceToken }}",
                           "authorities": [
                             "*"
                           ],

--- a/integration-tests/config_template.yaml
+++ b/integration-tests/config_template.yaml
@@ -18,10 +18,10 @@ bootstrap_extensions:
           {
             "delta_store_config": {
               "capacity": {{or .SingletonCapacity "100"}},
-              "periodical_flush": '{{or .SingletonPeriodicFlush "60"}}s',
-              "retry_duration": '{{or .SingletonRetryDuration "30"}}s',
+              "periodical_flush": "{{or .SingletonPeriodicFlush "60"}}s",
+              "retry_duration": "{{or .SingletonRetryDuration "30"}}s",
               "await_queue_capacity": {{or .SingletonQueueCapacity "200"}},
-              "flush_mode": '{{or .SingletonFlushMode "Default"}}'
+              "flush_mode": "{{or .SingletonFlushMode "Default"}}"
             }
           }
       vm_config:
@@ -100,8 +100,8 @@ static_resources:
                       },
                       "services": [
                         {
-                          "id": {{or .ServiceID "\"test-service-id\""}},
-                          "token": {{or .ServiceToken "\"test-service-token\""}},
+                          "id": "{{or .ServiceID "\"test-service-id\""}}",
+                          "token": "{{or .ServiceToken "\"test-service-token\""}}",
                           "authorities": [
                             "*"
                           ],

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"text/template"
-	"time"
 )
 
 func main() {
@@ -46,7 +45,6 @@ func StartProxy(dockerfile string, envoy string) error {
 		fmt.Printf("Error starting proxy container: %v", err)
 		return err
 	}
-	time.Sleep(15 * time.Second)
 	return nil
 }
 

--- a/integration-tests/singleton_flush_test.go
+++ b/integration-tests/singleton_flush_test.go
@@ -9,12 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type SingletonFlushTestSuite struct {
 	suite.Suite
+	backend      Backend
 	ServiceID    string
 	ServiceToken string
 	AppIDs       []string
@@ -38,74 +40,40 @@ func (suite *SingletonFlushTestSuite) SetupSuite() {
 
 }
 
+// Gets triggered before each test and runs the pre-conditions like setting up apisonator services
+// and generating envoy config from a template.
 func (suite *SingletonFlushTestSuite) BeforeTest(suiteName, testName string) {
 	if testName == "TestSingletonContainerFlush" {
-		configErr := configureSingletonFlush("ContainerLimit")
+		suite.ServiceID = uuid.NewString()
+		suite.ServiceToken = uuid.NewString()
+
+		// Configure the envoy template with ContainerLimit flush.
+		configErr := configureSingletonFlush("ContainerLimit", "100", "60", suite.ServiceID, suite.ServiceToken)
 		require.Nilf(suite.T(), configErr, "Error configuring envoy.yaml for container flush : %v", configErr)
+		suite.initializeApisonatorState()
 
-		require.Eventually(suite.T(), func() bool {
-			fmt.Printf("Creating service with service_id: %s, service_token:%s", suite.ServiceID, suite.ServiceToken)
-			serviceErr := CreateService(suite.ServiceID, suite.ServiceToken)
-			if serviceErr != nil {
-				return false
-			}
-			return true
-		}, 4*time.Second, 500*time.Millisecond, "Error creating the service")
+	} else if testName == "TestSingletonPeriodicalFlush" {
+		suite.ServiceID = uuid.NewString()
+		suite.ServiceToken = uuid.NewString()
 
-		for _, app := range suite.AppIDs {
-			require.Eventually(suite.T(), func() bool {
-				err := AddApplication(suite.ServiceID, app, suite.PlanID)
-				if err != nil {
-					return false
-				}
-				return true
-			}, 4*time.Second, 500*time.Millisecond, "Error creating the app")
-		}
-
-		require.Eventually(suite.T(), func() bool {
-			err := AddMetrics(suite.ServiceID, &suite.Metrics)
-			if err != nil {
-				return false
-			}
-			return true
-		}, 4*time.Second, 500*time.Millisecond, "Error adding metrics")
-
-		require.Eventually(suite.T(), func() bool {
-			err := UpdateUsageLimits(suite.ServiceID, suite.PlanID, &suite.Metrics)
-			if err != nil {
-				return false
-			}
-			return true
-		}, 4*time.Second, 500*time.Millisecond, "Error adding usage limits")
+		// Configure the envoy template with PeriodicalFlush. Flush period set as 10 seconds to check the apisonator values.
+		configErr := configureSingletonFlush("Periodical", "100", "10", suite.ServiceID, suite.ServiceToken)
+		require.Nilf(suite.T(), configErr, "Error configuring envoy.yaml for periodical flush: %v", configErr)
+		suite.initializeApisonatorState()
 	}
 
 }
 
-func configureSingletonFlush(flushMode string) error {
-	configData := []byte(fmt.Sprintf(`{ "SingletonFlushMode": "%s" }`, flushMode))
+// Generates envoy config from the template.
+func configureSingletonFlush(flushMode string, deltaStore string, periodical string, serviceID string, serviceToken string) error {
+	configData := []byte(fmt.Sprintf(`{ "SingletonFlushMode": "%s" , 
+										"SingletonPeriodicFlush": "%s", 
+										"SingletonCapacity": "%s",
+										"ServiceID": "%s",
+										"ServiceToken": "%s"
+									   }`,
+		flushMode, periodical, deltaStore, serviceID, serviceToken))
 	return GenerateConfig("temp.yaml", configData)
-}
-
-func (suite *SingletonFlushTestSuite) TestSingletonContainerFlush() {
-	upErr := StartProxy("./", "./temp.yaml")
-	require.Nilf(suite.T(), upErr, "Error starting proxy: %v", upErr)
-	client := &http.Client{}
-	req, errReq := http.NewRequest("GET", "http://127.0.0.1:9095/", nil)
-	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
-	req.Header = http.Header{
-		"Host":     []string{"localhost"},
-		"x-app-id": []string{"test-app-id-1"},
-	}
-	for i := 0; i < 4; i++ {
-		res, _ := client.Do(req)
-		fmt.Printf("Response: %v\n", res)
-	}
-	time.Sleep(3 * time.Second)
-	usage, usageErr := getApisonatorUsage("test-service-id", "test-service-token", "test-app-id-1")
-	require.Nilf(suite.T(), usageErr, "Error fetching usages from apisonator: %v", usageErr)
-	require.Equal(suite.T(), usage.Current, int64(4), "Invalid number for usages for the metric hits in apisonator")
-	downErr := StopProxy()
-	require.Nilf(suite.T(), downErr, "Error stopping proxy: %v", downErr)
 }
 
 func TestSingletonFlushSuite(t *testing.T) {
@@ -113,6 +81,7 @@ func TestSingletonFlushSuite(t *testing.T) {
 	suite.Run(t, new(SingletonFlushTestSuite))
 }
 
+// This helper method returns the usage for the hits metric which is used for the tests.
 func getApisonatorUsage(serviceID string, serviceToken string, appID string) (UsageReport, error) {
 	client := &http.Client{}
 	req, reqErr := http.NewRequest("GET", "http://127.0.0.1:3000/transactions/authorize.xml", nil)
@@ -138,46 +107,144 @@ func getApisonatorUsage(serviceID string, serviceToken string, appID string) (Us
 		fmt.Printf("XML Error: %v\n", xmlErr)
 	}
 	fmt.Printf("XML: %v\n", response)
-	return response.Usages[0], nil
+	for _, usage := range response.Usages {
+		if usage.Metric == "hits" {
+			return usage, nil
+		}
+	}
+	return UsageReport{}, fmt.Errorf("Usages for the metric not found")
 }
 
+// Gets triggered after each test and runs the post-conditions like deleting apisonator services
+// and deleting the temporary config file.
 func (suite *SingletonFlushTestSuite) AfterTest(suiteName, testName string) {
 	if testName == "TestSingletonContainerFlush" {
-		require.Eventually(suite.T(), func() bool {
-			fmt.Printf("Deleting service with service_id: %s, service_token:%s\n", suite.ServiceID, suite.ServiceToken)
-			serviceErr := DeleteService(suite.ServiceID, suite.ServiceToken)
-			if serviceErr != nil {
-				return false
-			}
-			return true
-		}, 4*time.Second, 500*time.Millisecond, "Error deleting the service")
-
-		for _, app := range suite.AppIDs {
-			require.Eventually(suite.T(), func() bool {
-				err := DeleteApplication(suite.ServiceID, app)
-				if err != nil {
-					return false
-				}
-				return true
-			}, 4*time.Second, 500*time.Millisecond, "Error deleting the app")
+		fmt.Println("Cleaning 3scale backend state")
+		flushErr := suite.backend.Flush()
+		if flushErr != nil {
+			fmt.Printf("Error flushing the backend state: %v", flushErr)
+			suite.backend.states = suite.backend.states[:0]
 		}
-
-		require.Eventually(suite.T(), func() bool {
-			err := DeleteMetrics(suite.ServiceID, &suite.Metrics)
-			if err != nil {
-				return false
-			}
-			return true
-		}, 4*time.Second, 500*time.Millisecond, "Error deleting metrics")
-
-		require.Eventually(suite.T(), func() bool {
-			err := DeleteUsageLimits(suite.ServiceID, suite.PlanID, &suite.Metrics)
-			if err != nil {
-				return false
-			}
-			return true
-		}, 4*time.Second, 500*time.Millisecond, "Error deleting usage limits")
 		deleteErr := os.Remove("./temp.yaml")
 		require.Nilf(suite.T(), deleteErr, "Error deleting temporary envoy.yaml")
+	} else if testName == "TestSingletonPeriodicalFlush" {
+		fmt.Println("Cleaning 3scale backend state")
+		flushErr := suite.backend.Flush()
+		if flushErr != nil {
+			fmt.Printf("Error flushing the backend state: %v", flushErr)
+			suite.backend.states = suite.backend.states[:0]
+		}
+		deleteErr := os.Remove("./temp.yaml")
+		require.Nilf(suite.T(), deleteErr, "Error deleting temporary envoy.yaml")
+	}
+}
+
+// This helper method initializes services, apps, metrics and usages in the apisonator for the tests.
+func (suite *SingletonFlushTestSuite) initializeApisonatorState() {
+	require.Eventually(suite.T(), func() bool {
+		fmt.Printf("Creating service with service_id: %s, service_token:%s", suite.ServiceID, suite.ServiceToken)
+		serviceErr := suite.backend.Push("service", []interface{}{suite.ServiceID, suite.ServiceToken})
+		if serviceErr != nil {
+			return false
+		}
+		return true
+	}, 4*time.Second, 500*time.Millisecond, "Error creating the service")
+
+	for _, app := range suite.AppIDs {
+		require.Eventually(suite.T(), func() bool {
+			err := suite.backend.Push("app", []interface{}{suite.ServiceID, app, suite.PlanID})
+			if err != nil {
+				return false
+			}
+			return true
+		}, 4*time.Second, 500*time.Millisecond, "Error creating the app")
+	}
+
+	require.Eventually(suite.T(), func() bool {
+		err := suite.backend.Push("metrics", []interface{}{suite.ServiceID, &suite.Metrics})
+		if err != nil {
+			return false
+		}
+		return true
+	}, 4*time.Second, 500*time.Millisecond, "Error adding metrics")
+
+	require.Eventually(suite.T(), func() bool {
+		err := suite.backend.Push("usage_limits", []interface{}{suite.ServiceID, suite.PlanID, &suite.Metrics})
+		if err != nil {
+			return false
+		}
+		return true
+	}, 4*time.Second, 500*time.Millisecond, "Error adding usage limits")
+
+}
+
+// ------------------- Test cases begin here ---------------------------------
+
+// This scenario tests the ContainerFlush scenario by sending requests and
+// flushing them based on the delta store container size. For this scenario, delta
+// store config is configured as 100.
+func (suite *SingletonFlushTestSuite) TestSingletonContainerFlush() {
+	upErr := StartProxy("./", "./temp.yaml")
+	require.Nilf(suite.T(), upErr, "Error starting proxy: %v", upErr)
+	client := &http.Client{}
+	req, errReq := http.NewRequest("GET", "http://127.0.0.1:9095/", nil)
+	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
+	req.Header = http.Header{
+		"Host":     []string{"localhost"},
+		"x-app-id": []string{"test-app-id-1"},
+	}
+	for i := 0; i < 4; i++ {
+		res, _ := client.Do(req)
+		fmt.Printf("Response: %v\n", res)
+	}
+	time.Sleep(3 * time.Second)
+	require.Eventually(suite.T(), func() bool {
+		usage, usageErr := getApisonatorUsage(suite.ServiceID, suite.ServiceToken, "test-app-id-1")
+		if usageErr != nil {
+			fmt.Printf("Error fetching apisonator usage: %v", usageErr)
+			return false
+		}
+		if usage.Current == int64(4) {
+			return true
+		}
+		return false
+	}, 5*time.Second, 1*time.Second, "Invalid number for usages for the metric hits in apisonator")
+	downErr := StopProxy()
+	require.Nilf(suite.T(), downErr, "Error stopping proxy: %v", downErr)
+}
+
+// This scenario tests the PeriodicalFlush scenario by sending requests,
+// wait for some time and check the apisonator usage. For this test periodical
+// time limit is configured as 10s.
+func (suite *SingletonFlushTestSuite) TestSingletonPeriodicalFlush() {
+	upErr := StartProxy("./", "./temp.yaml")
+	require.Nilf(suite.T(), upErr, "Error starting proxy: %v", upErr)
+	client := &http.Client{}
+	req, errReq := http.NewRequest("GET", "http://127.0.0.1:9095/", nil)
+	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
+	req.Header = http.Header{
+		"Host":     []string{"localhost"},
+		"x-app-id": []string{"test-app-id-1"},
+	}
+	for i := 0; i < 5; i++ {
+		res, _ := client.Do(req)
+		if i == 0 {
+			time.Sleep(5 * time.Second)
+		}
+		fmt.Printf("Response: %v\n", res)
+	}
+	require.Eventually(suite.T(), func() bool {
+		usage, usageErr := getApisonatorUsage(suite.ServiceID, suite.ServiceToken, "test-app-id-1")
+		if usageErr != nil {
+			fmt.Printf("Error fetching apisonator usage: %v", usageErr)
+			return false
+		}
+		if usage.Current == int64(5) {
+			return true
+		}
+		return false
+	}, 15*time.Second, 1*time.Second, "Invalid number for usages for the metric hits in apisonator")
+	if err := StopProxy(); err != nil {
+		fmt.Printf("Error stoping docker: %v", err)
 	}
 }


### PR DESCRIPTION
This PR includes
- Integration tests for singelton flush based on periodical flush
- Added UUID for keys to prevent dependency between test cases in case helper methods fail (If we use the same hard coded service ids , if the clean up methods fail for some reason then the successor tests also will fail when trying to create a service which already exists)
- Few other minor fixes