### PR TITLE
Cache tests and middleware for custom latency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
           golint -set_exit_status=1 ./...
       
       - name: Building application
-        run: make build CARGO_EXTRA_ARGS=--all-features
+        run: make build CACHE_EXTRA_ARGS=--all-features
 
       - name: Running Integration tests
         run: make integration    

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,8 @@
 build: export BUILD?=debug
 build: auth
 	@echo "> Building cache_filter and singleton_service"
-    ifeq ($(BUILD), release)
-		cargo build --target=wasm32-unknown-unknown --release $(CARGO_EXTRA_ARGS)
-    else
-		cargo build --target=wasm32-unknown-unknown $(CARGO_EXTRA_ARGS)
-    endif
+	make cache
+	make service
 	cp target/wasm32-unknown-unknown/$(BUILD)/cache_filter.wasm ./deployments/docker-compose/cache_filter.wasm
 	cp target/wasm32-unknown-unknown/$(BUILD)/singleton_service.wasm ./deployments/docker-compose/singleton_service.wasm
 
@@ -15,9 +12,9 @@ cache: export BUILD?=debug
 cache:
 	@echo "Building cache_filter"
     ifeq ($(BUILD), release)
-		cargo build --package cache-filter --target=wasm32-unknown-unknown --release $(CARGO_EXTRA_ARGS)
+		cargo build --package cache-filter --target=wasm32-unknown-unknown --release $(CACHE_EXTRA_ARGS)
     else
-		cargo build --package cache-filter --target=wasm32-unknown-unknown $(CARGO_EXTRA_ARGS) 
+		cargo build --package cache-filter --target=wasm32-unknown-unknown $(CACHE_EXTRA_ARGS) 
     endif
 	cp target/wasm32-unknown-unknown/$(BUILD)/cache_filter.wasm ./deployments/docker-compose/cache_filter.wasm
 

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -110,7 +110,7 @@ impl HttpContext for CacheFilter {
         self.req_data = request_data.clone();
 
         if let AppIdentifier::UserKey(ref user_key) = request_data.app_id {
-            match get_app_id_from_cache(&user_key) {
+            match get_app_id_from_cache(user_key) {
                 Ok(app_id) => {
                     request_data.app_id = AppIdentifier::from(app_id);
                     self.req_data.app_id = request_data.app_id.clone();

--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -58,4 +58,5 @@ services:
       - envoymesh 
 
 networks:
-  envoymesh: {}
+  envoymesh:
+    name: envoymesh

--- a/integration-tests/cache_test.go
+++ b/integration-tests/cache_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"os"
+	"net/http"
+	"time"
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
+)
+
+type CacheTestSuite struct {
+	suite.Suite
+	backend Backend
+	client http.Client
+}
+
+func (suite *CacheTestSuite) TestServiceManagementTimeout() {
+	configData := []byte(fmt.Sprintf(`{
+		"ClusterSocketAddress": "middleware",
+		"ClusterSocketPort": "3001",
+		"ServiceID": "%s",
+		"ServiceToken": "%s"
+	}`, uuid.NewString(), uuid.NewString()))
+	GenerateConfig("temp.yaml", configData)
+	StartProxy(".", "temp.yaml")
+	StartMiddleware()
+	require.Eventually(suite.T(), func() bool {
+		res, err := http.Get("http://localhost:9095/")
+		if err != nil {
+			return false
+		}
+		defer res.Body.Close()
+		return true
+	}, 15*time.Second, 1*time.Second, "Envoy has not started")
+
+	// Initializing backend state is not required since we are testing for timeout
+	req, errReq := http.NewRequest("GET", "http://localhost:9095/", nil)
+	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
+	req.Header = http.Header{
+		"Host":     []string{"localhost"},
+		"x-app-id": []string{"does-not-matter"},
+	}
+
+	res, resErr := suite.client.Do(req)
+	require.Nilf(suite.T(), resErr, "Error sending the HTTP request: %v", resErr)
+	
+	var logs []string
+	unmarshalErr := json.Unmarshal([]byte(res.Header["Filter-Logs"][0]), &logs)
+	require.Nilf(suite.T(), unmarshalErr, "Error while unmarshaling: %v", unmarshalErr)
+
+	patterns := []string{".*cache miss.*", ".*dispatch successful.*", ".*received response.*", ".*Unexpected characters.*"}
+	patternsMatched := SerialSearch(logs, patterns)
+	assert.Equal(suite.T(), true, patternsMatched, "All patterns are not matched! Logs: %v", logs)
+
+	deleteErr := os.Remove("./temp.yaml")
+	require.Nilf(suite.T(), deleteErr, "Error deleting temporary config file")
+	StopProxy()
+	StopMiddleware()
+}
+
+func (suite *CacheTestSuite) TestCacheHit() {
+	// Apisonator state
+	serviceID := uuid.NewString()
+	serviceToken := uuid.NewString()
+	appID := "test-app-id"
+	userKey := "test-user-key"
+	planID := "test-plan-id"
+	metrics := []Metric{{"hits", "1", []UsageLimit{},}}
+
+	// Initializing apisonator state
+	serviceErr := suite.backend.Push("service", []interface{}{serviceID, serviceToken})
+	require.Nilf(suite.T(), serviceErr, "Error creating a service: %v", serviceErr)
+	appErr := suite.backend.Push("app", []interface{}{serviceID, appID, planID})
+	require.Nilf(suite.T(), appErr, "Error creating an app: %v", appErr)
+	userKeyErr := suite.backend.Push("user_key", []interface{}{serviceID, appID, userKey})
+	require.Nilf(suite.T(), userKeyErr, "Error creating an user key: %v", userKeyErr)
+	metricsErr := suite.backend.Push("metrics", []interface{}{serviceID, &metrics})
+	require.Nilf(suite.T(), metricsErr, "Error adding metrics: %v", metricsErr)
+	
+	// Generating custom config and starting proxy with it
+	configData := []byte(fmt.Sprintf(`{
+		"ServiceID": "%s",
+		"ServiceToken": "%s" 
+	}`, serviceID, serviceToken))
+	GenerateConfig("temp.yaml", configData)
+	StartProxy(".", "temp.yaml")
+	require.Eventually(suite.T(), func() bool {
+		res, err := http.Get("http://localhost:9095/")
+		if err != nil {
+			return false
+		}
+		defer res.Body.Close()
+		return true
+	}, 15*time.Second, 1*time.Second, "Envoy has not started")
+
+	// Sending requests and doing pattern match based on the response
+	req, reqErr := http.NewRequest("GET", "http://localhost:9095", nil)
+	require.Nilf(suite.T(), reqErr, "Error while creating request: %v", reqErr)
+	q := req.URL.Query()
+	q.Add("api_key", userKey)
+	req.URL.RawQuery = q.Encode()
+	patterns1 := []string{".*cache miss.*", ".*dispatch successful.*", ".*received response.*"}
+	patterns2 := []string{".*cache hit.*", ".*allowed to pass.*"}
+	for i := 1; i <= 2; i++ {
+		res, resErr := suite.client.Do(req)
+		require.Nilf(suite.T(), resErr, "Error while sending the request: %v", resErr)
+
+		var logs []string
+		unmarshalErr := json.Unmarshal([]byte(res.Header["Filter-Logs"][0]), &logs)
+		require.Nilf(suite.T(), unmarshalErr, "Error while unmarshaling: %v", unmarshalErr)
+
+		var patternsMatched bool
+		if i == 1 {
+			patternsMatched = SerialSearch(logs, patterns1)
+		} else {
+			patternsMatched = SerialSearch(logs, patterns2)
+		}
+		assert.Equal(suite.T(), true, patternsMatched, "All patterns are not matched for the request#%d ! Logs: %v", i, logs)
+	}
+
+	// Cleanup
+	flushErr := suite.backend.Flush()
+	require.Nilf(suite.T(), flushErr, "Error while flushing apisonator state: %v", flushErr)
+	deleteErr := os.Remove("./temp.yaml")
+	require.Nilf(suite.T(), deleteErr, "Error deleting temporary config file")
+	StopProxy()
+}
+
+func (suite *CacheTestSuite) TestRateLimitFlow() {
+	// Apisonator state
+	serviceID := uuid.NewString()
+	serviceToken := uuid.NewString()
+	appID := "test-app-id"
+	planID := "test-plan-id"
+	metrics := []Metric{{"hits", "1", []UsageLimit{{Day, 4},},}}
+
+	// Initializing apisonator state
+	serviceErr := suite.backend.Push("service", []interface{}{serviceID, serviceToken})
+	require.Nilf(suite.T(), serviceErr, "Error creating a service: %v", serviceErr)
+	appErr := suite.backend.Push("app", []interface{}{serviceID, appID, planID})
+	require.Nilf(suite.T(), appErr, "Error creating an app: %v", appErr)
+	metricsErr := suite.backend.Push("metrics", []interface{}{serviceID, &metrics})
+	require.Nilf(suite.T(), metricsErr, "Error adding metrics: %v", metricsErr)
+	limitErr := suite.backend.Push("usage_limits", []interface{}{serviceID, planID, &metrics})
+	require.Nilf(suite.T(), limitErr, "Error adding limits to metrics: %v", limitErr)
+
+	// Generating custom config and starting proxy with it
+	configData := []byte(fmt.Sprintf(`{
+		"ServiceID": "%s",
+		"ServiceToken": "%s" 
+	}`, serviceID, serviceToken))
+	GenerateConfig("temp.yaml", configData)
+	StartProxy(".", "temp.yaml")
+	require.Eventually(suite.T(), func() bool {
+		res, err := http.Get("http://localhost:9095/")
+		if err != nil {
+			return false
+		}
+		defer res.Body.Close()
+		return true
+	}, 15*time.Second, 1*time.Second, "Envoy has not started")
+
+	req, errReq := http.NewRequest("GET", "http://localhost:9095/", nil)
+	require.Nilf(suite.T(), errReq, "Error creating the HTTP request: %v", errReq)
+	req.Header = http.Header{
+		"Host":     []string{"localhost"},
+		"x-app-id": []string{appID},
+	}
+	
+	notLimitedPattern := []string{".*request is allowed.*"}
+	rateLimitedPattern := []string{".*request is rate-limited"}
+	for i := 1; i <= 6; i++ {
+		res, resErr := suite.client.Do(req)
+		require.Nilf(suite.T(), resErr, "Error while sending the request: %v", resErr)
+		fmt.Printf("Response #%d: %v\n", i, res)
+
+		var logs []string
+		unmarshalErr := json.Unmarshal([]byte(res.Header["Filter-Logs"][0]), &logs)
+		require.Nilf(suite.T(), unmarshalErr, "Error while unmarshaling: %v", unmarshalErr)
+
+		var patternsMatched bool
+		if i <= 5 {
+			patternsMatched = SerialSearch(logs, notLimitedPattern)
+		} else {
+			patternsMatched = SerialSearch(logs, rateLimitedPattern)
+		}
+		assert.Equal(suite.T(), true, patternsMatched, "All patterns are not matched for the request#%d ! Logs: %v", i, logs)
+	}
+
+	// Cleanup
+	flushErr := suite.backend.Flush()
+	require.Nilf(suite.T(), flushErr, "Error while flushing apisonator state: %v", flushErr)
+	deleteErr := os.Remove("./temp.yaml")
+	require.Nilf(suite.T(), deleteErr, "Error deleting temporary config file")
+	StopProxy()
+}
+
+func TestCacheSuite(t *testing.T) {
+	fmt.Println("Running ==TestCacheSuite==")
+	suite.Run(t, new(CacheTestSuite))
+}

--- a/integration-tests/cache_test.go
+++ b/integration-tests/cache_test.go
@@ -1,23 +1,23 @@
 package main
 
 import (
-	"fmt"
-	"testing"
-	"os"
-	"net/http"
-	"time"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/stretchr/testify/assert"
 )
 
 type CacheTestSuite struct {
 	suite.Suite
 	backend Backend
-	client http.Client
+	client  http.Client
 }
 
 func (suite *CacheTestSuite) TestServiceManagementTimeout() {
@@ -49,7 +49,7 @@ func (suite *CacheTestSuite) TestServiceManagementTimeout() {
 
 	res, resErr := suite.client.Do(req)
 	require.Nilf(suite.T(), resErr, "Error sending the HTTP request: %v", resErr)
-	
+
 	var logs []string
 	unmarshalErr := json.Unmarshal([]byte(res.Header["Filter-Logs"][0]), &logs)
 	require.Nilf(suite.T(), unmarshalErr, "Error while unmarshaling: %v", unmarshalErr)
@@ -71,7 +71,7 @@ func (suite *CacheTestSuite) TestCacheHit() {
 	appID := "test-app-id"
 	userKey := "test-user-key"
 	planID := "test-plan-id"
-	metrics := []Metric{{"hits", "1", []UsageLimit{},}}
+	metrics := []Metric{{"hits", "1", []UsageLimit{}}}
 
 	// Initializing apisonator state
 	serviceErr := suite.backend.Push("service", []interface{}{serviceID, serviceToken})
@@ -82,7 +82,7 @@ func (suite *CacheTestSuite) TestCacheHit() {
 	require.Nilf(suite.T(), userKeyErr, "Error creating an user key: %v", userKeyErr)
 	metricsErr := suite.backend.Push("metrics", []interface{}{serviceID, &metrics})
 	require.Nilf(suite.T(), metricsErr, "Error adding metrics: %v", metricsErr)
-	
+
 	// Generating custom config and starting proxy with it
 	configData := []byte(fmt.Sprintf(`{
 		"ServiceID": "%s",
@@ -138,7 +138,7 @@ func (suite *CacheTestSuite) TestRateLimitFlow() {
 	serviceToken := uuid.NewString()
 	appID := "test-app-id"
 	planID := "test-plan-id"
-	metrics := []Metric{{"hits", "1", []UsageLimit{{Day, 4},},}}
+	metrics := []Metric{{"hits", "1", []UsageLimit{{Day, 4}}}}
 
 	// Initializing apisonator state
 	serviceErr := suite.backend.Push("service", []interface{}{serviceID, serviceToken})
@@ -172,20 +172,23 @@ func (suite *CacheTestSuite) TestRateLimitFlow() {
 		"Host":     []string{"localhost"},
 		"x-app-id": []string{appID},
 	}
-	
+
 	notLimitedPattern := []string{".*request is allowed.*"}
 	rateLimitedPattern := []string{".*request is rate-limited"}
-	for i := 1; i <= 6; i++ {
+	for i := 1; i <= 5; i++ {
 		res, resErr := suite.client.Do(req)
 		require.Nilf(suite.T(), resErr, "Error while sending the request: %v", resErr)
 		fmt.Printf("Response #%d: %v\n", i, res)
+
+		// Allow proxy to process the request and make the test more predictable
+		time.Sleep(200 * time.Millisecond)
 
 		var logs []string
 		unmarshalErr := json.Unmarshal([]byte(res.Header["Filter-Logs"][0]), &logs)
 		require.Nilf(suite.T(), unmarshalErr, "Error while unmarshaling: %v", unmarshalErr)
 
 		var patternsMatched bool
-		if i <= 5 {
+		if i < 5 {
 			patternsMatched = SerialSearch(logs, notLimitedPattern)
 		} else {
 			patternsMatched = SerialSearch(logs, rateLimitedPattern)

--- a/integration-tests/config_template.yaml
+++ b/integration-tests/config_template.yaml
@@ -296,4 +296,4 @@ static_resources:
             address:
               socket_address:
                 address: {{or .ClusterSocketAddress "listener"}}
-                port_value: 3000
+                port_value: {{or .ClusterSocketPort "3000"}}

--- a/integration-tests/config_test.go
+++ b/integration-tests/config_test.go
@@ -44,7 +44,7 @@ func (suite *ConfigTestSuite) TestServiceNotFound() {
 	}
 
 	res, resErr := suite.client.Do(req)
-	require.Nilf(suite.T(), resErr, "Error creating the HTTP request: %v", resErr)
+	require.Nilf(suite.T(), resErr, "Error sending the HTTP request: %v", resErr)
 
 	var logs []string
 	unmarshalErr := json.Unmarshal([]byte(res.Header["Filter-Logs"][0]), &logs)
@@ -141,6 +141,6 @@ func (suite *ConfigTestSuite) TestWrongClusterName() {
 }
 
 func TestConfigSuite(t *testing.T) {
-	fmt.Println("Running TestConfigSuite")
+	fmt.Println("Running ==TestConfigSuite==")
 	suite.Run(t, new(ConfigTestSuite))
 }

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -60,7 +60,33 @@ func StopProxy() error {
 		return err
 	}
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(15 * time.Second)
+	return nil
+}
+
+// StartMiddleware build and starts the middleware in a docker container.
+func StartMiddleware() error {
+	cmd := exec.Command("sh", "-c", "docker build middleware -f ./middleware/Dockerfile && docker run -d --network envoymesh --name middleware middleware")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Error starting middleware container: %v", err)
+		return err
+	}
+	time.Sleep(6*time.Second)
+	return nil
+}
+
+// StopMiddleware stops the container running middleware.
+func StopMiddleware() error {
+	cmd := exec.Command("sh", "-c", "docker rm -f middleware")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Error removing middleware container: %v", err)
+		return err
+	}
+	time.Sleep(2 * time.Second)
 	return nil
 }
 

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -66,14 +66,14 @@ func StopProxy() error {
 
 // StartMiddleware build and starts the middleware in a docker container.
 func StartMiddleware() error {
-	cmd := exec.Command("sh", "-c", "docker build middleware -f ./middleware/Dockerfile && docker run -d --network envoymesh --name middleware middleware")
+	cmd := exec.Command("sh", "-c", "docker build -t middleware -f ./middleware/Dockerfile ./middleware --no-cache && docker run -d --network envoymesh --name middleware middleware")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("Error starting middleware container: %v", err)
 		return err
 	}
-	time.Sleep(6*time.Second)
+	time.Sleep(6 * time.Second)
 	return nil
 }
 

--- a/integration-tests/middleware/Dockerfile
+++ b/integration-tests/middleware/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:latest
+
+COPY ./index.js ./index.js
+COPY ./package.json ./package.json 
+
+RUN npm install
+
+EXPOSE 3001
+CMD [ "node", "index.js" ]

--- a/integration-tests/middleware/index.js
+++ b/integration-tests/middleware/index.js
@@ -1,0 +1,22 @@
+const express = require("express")
+const app = express()
+const PORT = 3001
+
+const proxy = require('http-proxy').createProxyServer({
+    preserveHeaderKeyCase: true,
+    target: "http://listener:3000/"
+});
+
+function sleep(ms) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+} 
+
+app.all("*", async (req, res, next) => {
+    await sleep(6000)
+    console.log(`Received request: ${req}`)
+    proxy.web(req, res, next);
+})
+
+app.listen(PORT,()=>{console.log(`Lstening on port ${PORT}`)})

--- a/integration-tests/middleware/package.json
+++ b/integration-tests/middleware/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "middleware",
+  "version": "1.0.0",
+  "description": "middleware for integration testing",
+  "main": "index.js",
+  "scripts": {
+    "test": "test"
+  },
+  "author": "Rahul Anand <rahulanand16nov@gmail.com>",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.17.1",
+    "http-proxy": "^1.18.1"
+  }
+}

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -220,13 +220,13 @@ impl Context for SingletonService {
                     // TODO : Handle auth processing.
                     #[allow(unused_must_use)]
                     {
-                        self.handle_auth_response(bytes, &status);
+                        self.handle_auth_response(bytes, status);
                     }
                 }
                 None => {
                     if self.report_requests.contains_key(&token_id) {
                         info!("Report response");
-                        self.handle_report_response(&status, &token_id);
+                        self.handle_report_response(status, &token_id);
                     }
                 }
             }
@@ -236,7 +236,7 @@ impl Context for SingletonService {
                 token_id
             );
             if self.report_requests.contains_key(&token_id) {
-                self.handle_report_response(&status, &token_id);
+                self.handle_report_response(status, &token_id);
             }
         }
     }
@@ -472,6 +472,6 @@ impl SingletonService {
     fn handle_report_response(&mut self, status: &str, token_id: &u32) {
         // TODO : Handle report failure.
         info!("Report status : {} {}", status, token_id);
-        self.report_requests.remove(&token_id);
+        self.report_requests.remove(token_id);
     }
 }

--- a/threescale/src/proxy.rs
+++ b/threescale/src/proxy.rs
@@ -93,8 +93,8 @@ pub fn set_app_id_to_cache(user_key: &UserKey, app_id: &AppId) -> Result<(), Cac
 pub fn set_application_to_cache(key: &str, app: &Application, cas: u32) -> bool {
     info!("setting application with key: {}", key);
     match set_shared_data(
-        &key,
-        Some(&bincode::serialize::<Application>(&app).unwrap()),
+        key,
+        Some(&bincode::serialize::<Application>(app).unwrap()),
         Some(cas),
     ) {
         Ok(()) => true,

--- a/threescale/src/utils.rs
+++ b/threescale/src/utils.rs
@@ -57,7 +57,7 @@ pub fn limit_check_and_update_application(
 
     // request is not rate-limited and will be set to cache
     let cache_key = CacheKey::from(&app.service_id, &app.app_id);
-    if !set_application_to_cache(&cache_key.as_string(), &app, app_cas) {
+    if !set_application_to_cache(&cache_key.as_string(), app, app_cas) {
         return Err(UpdateMetricsError::CacheUpdateFail);
     }
     Ok(())


### PR DESCRIPTION
This PR adds tests for cache and touches 90+% of the cache-filter code. Along with tests, I have added a middleware service to add custom delays into the reply from apisonator for the cache. 
