### PR TITLE
Memory limit on shared data

### DIFF
--- a/cache-filter/src/configuration.rs
+++ b/cache-filter/src/configuration.rs
@@ -7,6 +7,8 @@ pub struct FilterConfig {
     pub failure_mode_deny: bool,
     /// Number of retries for setting data to cache
     pub max_tries: u32,
+    /// Max memory in bytes that shared data is allowed to use.
+    pub max_shared_memory_bytes: u64,
 }
 
 impl Default for FilterConfig {
@@ -14,6 +16,7 @@ impl Default for FilterConfig {
         FilterConfig {
             failure_mode_deny: true,
             max_tries: 5,
+            max_shared_memory_bytes: 4294967296, // equivalent to 4GB
         }
     }
 }

--- a/cache-filter/src/configuration.rs
+++ b/cache-filter/src/configuration.rs
@@ -11,12 +11,14 @@ pub struct FilterConfig {
     pub max_shared_memory_bytes: u64,
 }
 
+const DEFAULT_MAX_SHARED_MEMORY: u64 = 4294967296;
+
 impl Default for FilterConfig {
     fn default() -> Self {
         FilterConfig {
             failure_mode_deny: true,
             max_tries: 5,
-            max_shared_memory_bytes: 4294967296, // equivalent to 4GB
+            max_shared_memory_bytes: DEFAULT_MAX_SHARED_MEMORY, // equivalent to 4GB
         }
     }
 }

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -211,12 +211,13 @@ impl CacheFilter {
                     rate_limited = true;
                     break;
                 }
-                Err(UpdateMetricsError::CacheUpdateFail) => {
+                Err(UpdateMetricsError::CacheUpdateFail(reason)) => {
                     info!(
                         self.context_id,
-                        "try ({} out of {}): failed to set application to cache",
+                        "try ({} out of {}): failed to set application to cache: {}",
                         (num_try as u64) + 1,
-                        max_tries
+                        max_tries,
+                        reason
                     );
                     if num_try < max_tries {
                         match get_application_from_cache(&self.cache_key) {

--- a/integration-tests/cache_test.go
+++ b/integration-tests/cache_test.go
@@ -181,7 +181,7 @@ func (suite *CacheTestSuite) TestRateLimitFlow() {
 		fmt.Printf("Response #%d: %v\n", i, res)
 
 		// Allow proxy to process the request and make the test more predictable
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(300 * time.Millisecond)
 
 		var logs []string
 		unmarshalErr := json.Unmarshal([]byte(res.Header["Filter-Logs"][0]), &logs)

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -40,8 +40,8 @@ pub enum SingletonServiceError {
     #[error("Error retrieving local cache entry for cache key: {0}")]
     GetCacheFailure(String),
 
-    #[error("Error settiing local cache entry for cache key: {0}")]
-    SetCacheFailure(String),
+    #[error("Error setting local cache entry for cache key: {0}: {1}")]
+    SetCacheFailure(String, String),
 
     #[error("Empty reports for authorize for app_id: {0}")]
     EmptyAuthUsages(String),
@@ -277,9 +277,10 @@ impl SingletonService {
                     req_time,
                 ) {
                     Ok(()) => Ok(()),
-                    Err(UpdateMetricsError::CacheUpdateFail) => {
+                    Err(UpdateMetricsError::CacheUpdateFail(reason)) => {
                         anyhow::bail!(SingletonServiceError::SetCacheFailure(
-                            cache_key.as_string()
+                            cache_key.as_string(),
+                            reason
                         ))
                     }
                     Err(e) => {
@@ -463,12 +464,11 @@ impl SingletonService {
                         };
                     }
 
-                    set_application_to_cache(
+                    return set_application_to_cache(
                         CacheKey::from(&service_id, &app_id).as_string().as_ref(),
                         &app,
                         0,
                     );
-                    Ok(())
                 } else {
                     anyhow::bail!(SingletonServiceError::AuthResponse)
                 }

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use thiserror::Error;
 use threescale::{
     proxy::{
-        get_application_from_cache, set_application_to_cache, CacheKey, SHARED_MEMORY_INITIAL_SIZE,
-        SHARED_MEMORY_KEY,
+        get_application_from_cache, set_application_to_cache, CacheKey, SHARED_MEMORY_COUNTER_KEY,
+        SHARED_MEMORY_INITIAL_SIZE,
     },
     structs::{
         AppId, AppIdentifier, AppKey, Application, Message, Period, PeriodWindow, ServiceId,
@@ -109,7 +109,7 @@ impl RootContext for SingletonService {
 
         // Initialize shared memory counter with anything that's not significant.
         if let Err(e) = set_shared_data(
-            SHARED_MEMORY_KEY,
+            SHARED_MEMORY_COUNTER_KEY,
             Some(&SHARED_MEMORY_INITIAL_SIZE.to_be_bytes()),
             None,
         ) {

--- a/threescale/src/proxy.rs
+++ b/threescale/src/proxy.rs
@@ -1,7 +1,11 @@
 use crate::structs::{AppId, AppIdentifier, Application, ServiceId, UserKey};
-use log::{debug, info};
+use log::{debug, info, warn};
 use proxy_wasm::hostcalls::{get_shared_data, set_shared_data};
+use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
+
+pub const SHARED_MEMORY_KEY: &str = "SHARED_MEMORY_COUNTER";
+pub const SHARED_MEMORY_INITIAL_SIZE: u64 = 1000;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CacheError {
@@ -13,7 +17,7 @@ pub enum CacheError {
     Utf8Fail(#[from] std::str::Utf8Error),
     #[error("failure caused by an underlying proxy issue")]
     ProxyStatus(u8),
-    #[error("deserializing usage data failed")]
+    #[error("deserializing bincode data failed")]
     DeserializeFail(#[from] bincode::ErrorKind),
 }
 
@@ -92,15 +96,79 @@ pub fn set_app_id_to_cache(user_key: &UserKey, app_id: &AppId) -> Result<(), Cac
 // returns false on set failure
 pub fn set_application_to_cache(key: &str, app: &Application, cas: u32) -> bool {
     info!("setting application with key: {}", key);
-    match set_shared_data(
-        key,
-        Some(&bincode::serialize::<Application>(app).unwrap()),
-        Some(cas),
-    ) {
-        Ok(()) => true,
-        Err(e) => {
-            debug!("set operation failed for key: {} : {:?}", key, e);
-            false
+    let prev_memory_usage = get_cache_pair_size(key) as i32;
+    let serialized_app = bincode::serialize::<Application>(app).unwrap();
+    let memory_delta: i32 = (key.len() as i32) + (serialized_app.len() as i32) - prev_memory_usage;
+    if let Err(e) = set_shared_data(key, Some(&serialized_app), Some(cas)) {
+        debug!("set operation failed for key: {} : {:?}", key, e);
+        return false;
+    }
+    for num_try in 0..3 {
+        match update_shared_memory_size(memory_delta) {
+            Ok(()) => break,
+            Err(e) => debug!("try#{} : failed to update memory counter: {}", num_try, e),
         }
     }
+    true
+}
+
+// returns memory used in bytes for both key and value pair stored.
+fn get_cache_pair_size(key: &str) -> usize {
+    match get_shared_data(key) {
+        Ok((Some(bytes), _)) => key.len() + bytes.len(),
+        Ok((None, _)) => key.len(),
+        Err(_) => 0,
+    }
+}
+
+// Adds delta bytes to the shared memory usage counter
+fn update_shared_memory_size(delta: i32) -> Result<(), anyhow::Error> {
+    let current_size = match get_shared_data(SHARED_MEMORY_KEY) {
+        Ok((Some(bytes), _)) => {
+            let arr: [u8; 8] = match bytes.try_into() {
+                Ok(res) => res,
+                Err(e) => anyhow::bail!("failed to convert vec<u8> to [u8;8]: {:?}", e),
+            };
+            u64::from_be_bytes(arr)
+        }
+        Ok((None, _)) => {
+            warn!("shared memory size was not initialized at the start or got deleted somehow!");
+            if let Err(e) = set_shared_data(
+                SHARED_MEMORY_KEY,
+                Some(&SHARED_MEMORY_INITIAL_SIZE.to_be_bytes()),
+                None,
+            ) {
+                anyhow::bail!(
+                    "failed to initialize shared memory size: {:?}",
+                    CacheError::ProxyStatus(e as u8)
+                )
+            }
+            SHARED_MEMORY_INITIAL_SIZE
+        }
+        Err(e) => anyhow::bail!(
+            "getting shared memory size failed: {:?}",
+            CacheError::ProxyStatus(e as u8)
+        ),
+    };
+
+    let final_size: u64;
+    if delta.is_negative() {
+        if current_size <= (-delta).try_into().unwrap() {
+            // This condition is theoretically not possible because memory should keep on
+            // increasing since we have no option of deleting the data. So, check your calcs!
+            final_size = SHARED_MEMORY_INITIAL_SIZE;
+        } else {
+            final_size = current_size.saturating_sub((-delta).try_into().unwrap());
+        }
+    } else {
+        final_size = current_size.saturating_add((-delta).try_into().unwrap());
+    }
+
+    if let Err(e) = set_shared_data(SHARED_MEMORY_KEY, Some(&final_size.to_be_bytes()), None) {
+        anyhow::bail!(
+            "failed to update shared memory size: {:?}",
+            CacheError::ProxyStatus(e as u8)
+        )
+    }
+    Ok(())
 }

--- a/threescale/src/utils.rs
+++ b/threescale/src/utils.rs
@@ -8,8 +8,8 @@ pub enum UpdateMetricsError {
     DurationOverflow,
     #[error("request is rate-limited")]
     RateLimited,
-    #[error("application set was unsuccessful")]
-    CacheUpdateFail,
+    #[error("application set was unsuccessful: {0}")]
+    CacheUpdateFail(String),
 }
 
 // updates application to reflect consumed quota if not rate-limited
@@ -57,8 +57,8 @@ pub fn limit_check_and_update_application(
 
     // request is not rate-limited and will be set to cache
     let cache_key = CacheKey::from(&app.service_id, &app.app_id);
-    if !set_application_to_cache(&cache_key.as_string(), app, app_cas) {
-        return Err(UpdateMetricsError::CacheUpdateFail);
+    if let Err(e) = set_application_to_cache(&cache_key.as_string(), app, app_cas) {
+        return Err(UpdateMetricsError::CacheUpdateFail(e.to_string()));
     }
     Ok(())
 }


### PR DESCRIPTION
This PR adds the ability to limit memory consumed by shared data since it can fill up very quickly in a production environment. What should happen if the memory limit is reached is still undefined and a possible solution is to allow singleton to evict cache as someone needs to store keys present in the cache with some policy for eviction.