### PR TITLE
Delete apps stored in the cache

### DIFF
--- a/deployments/docker-compose/envoy.yaml
+++ b/deployments/docker-compose/envoy.yaml
@@ -100,8 +100,8 @@ static_resources:
                       },
                       "services": [
                         {
-                          "id": "test_service_id",
-                          "token": "test_service_token",
+                          "id": "test-service-id",
+                          "token": "test-service-token",
                           "authorities": [
                             "*"
                           ],

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use thiserror::Error;
 use threescale::{
     proxy::{
-        get_application_from_cache, set_application_to_cache, CacheKey, SHARED_MEMORY_COUNTER_KEY,
-        SHARED_MEMORY_INITIAL_SIZE,
+        get_application_from_cache, remove_application_from_cache, set_application_to_cache,
+        CacheKey, SHARED_MEMORY_COUNTER_KEY, SHARED_MEMORY_INITIAL_SIZE,
     },
     structs::{
         AppId, AppIdentifier, AppKey, Application, Message, Period, PeriodWindow, ServiceId,
@@ -484,11 +484,17 @@ impl SingletonService {
                         };
                     }
 
-                    return set_application_to_cache(
+                    match set_application_to_cache(
                         CacheKey::from(&service_id, &app_id).as_string().as_ref(),
                         &app,
                         0,
-                    );
+                    ) {
+                        Ok(()) => Ok(()),
+                        Err(_err) => Err(SingletonServiceError::SetCacheFailure(
+                            service_id.as_ref().to_string(),
+                            app_id.as_ref().to_string(),
+                        )),
+                    }
                 } else {
                     Err(SingletonServiceError::AuthResponse)
                 }

--- a/threescale/src/proxy.rs
+++ b/threescale/src/proxy.rs
@@ -193,7 +193,7 @@ fn update_shared_memory_size(delta: i32) -> Result<(), anyhow::Error> {
 // to delete an application in case a 404 response is received for the
 // authorize call. Due to unavailability of a deletion API, set_shared_data
 // is used by setting the value as None. However a memory leak occur from the keys.
-// Refer to the upstream isssue here: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/issues/109 
+// Refer to the upstream isssue here: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/issues/109
 pub fn remove_application_from_cache(key: &str) {
     match set_shared_data(key, None, None) {
         Ok(()) => {

--- a/threescale/src/proxy.rs
+++ b/threescale/src/proxy.rs
@@ -188,3 +188,19 @@ fn update_shared_memory_size(delta: i32) -> Result<(), anyhow::Error> {
     }
     Ok(())
 }
+
+// Deletes an application from the cache. Used by the singleton service
+// to delete an application in case a 404 response is received for the
+// authorize call. Due to unavailability of a deletion API, set_shared_data
+// is used by setting the value as None. However a memory leak occur from the keys.
+// Refer to the upstream isssue here: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/issues/109 
+pub fn remove_application_from_cache(key: &str) {
+    match set_shared_data(key, None, None) {
+        Ok(()) => {
+            info!("Deleting application with key: {} successful", key)
+        }
+        Err(err) => {
+            info!("Error deleting application with key: {} {:?}", key, err)
+        }
+    }
+}


### PR DESCRIPTION
Deleting apps stored in the cache when the 3scale SM API returns an authorization error. 