### PR TITLE
cache_root: initialize PRNG for thread id

### DIFF
--- a/cache-filter/Cargo.toml
+++ b/cache-filter/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["cache filter"]
 crate-type = ["cdylib"]
 
 [features]
+default = ["prng_pcg32"]
 visible_logs = []
+prng_pcg32 = ["rand_pcg"]
+prng_xoshiro128 = ["rand_xoshiro"]
+prng_xorshift = ["rand_xorshift"]
 
 [dependencies]
 threescale = { path = "../threescale" }
@@ -28,3 +32,11 @@ threescalers = { git = "https://github.com/3scale-rs/threescalers", branch = "ma
 serde_xml = "0.9"
 thiserror = "1.0"
 url = { git = "https://github.com/3scale-rs/rust-url", branch = "3scale", features = ["serde"] }
+
+rand = { version = "^0.8", default-features = false }
+rand_seeder = { version = "^0.2" }
+rand_jitter = { version = "^0.3" }
+# PRNG implementation
+rand_xoshiro = { version = "^0.6", optional = true }
+rand_xorshift = { version = "^0.3", optional = true }
+rand_pcg = { version = "^0.3", optional = true }

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -79,6 +79,7 @@ pub enum RequestDataError {
 
 pub struct CacheFilter {
     pub context_id: u32,
+    pub root_id: u32,
     pub config: FilterConfig,
     pub update_cache_from_singleton: bool,
     pub cache_key: CacheKey,

--- a/cache-filter/src/rand.rs
+++ b/cache-filter/src/rand.rs
@@ -1,0 +1,9 @@
+use proxy_wasm::traits::Context;
+
+mod seeding;
+pub use seeding::Error;
+
+pub mod thread_rng;
+pub use thread_rng::{thread_rng_init, thread_rng_init_fallible};
+
+mod prng;

--- a/cache-filter/src/rand/prng.rs
+++ b/cache-filter/src/rand/prng.rs
@@ -1,0 +1,61 @@
+use rand::{RngCore, SeedableRng};
+
+use super::seeding;
+use super::Context;
+
+#[repr(transparent)]
+pub struct Prng<R: SeedableRng> {
+    rng: R,
+}
+
+impl<R: RngCore + SeedableRng> Prng<R> {
+    pub fn new(ctx: &(dyn Context + Send + Sync), context_id: u32) -> Result<Self, seeding::Error> {
+        Ok(Self {
+            rng: seeding::seed(ctx, context_id)?,
+        })
+    }
+}
+
+impl<R: RngCore + SeedableRng> rand::RngCore for Prng<R> {
+    fn next_u32(&mut self) -> u32 {
+        self.rng.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.rng.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.rng.try_fill_bytes(dest)
+    }
+}
+
+#[cfg(not(any(
+    feature = "prng_xorshift",
+    feature = "prng_xoshiro128ss",
+    feature = "prng_pcg32"
+)))]
+compile_error!("at least one PRNG implementation must be chosen via feature flags");
+
+#[cfg(feature = "prng_xoshiro128ss")]
+pub type DefaultPRNG = rand_xoshiro::Xoshiro128StarStar;
+
+#[cfg(all(feature = "prng_pcg32", not(feature = "prng_xoshiro128ss")))]
+pub type DefaultPRNG = rand_pcg::Lcg64Xsh32;
+
+#[cfg(all(
+    feature = "prng_xorshift",
+    not(any(feature = "pcrng_xoshiro128ss", feature = "prng_pcg32"))
+))]
+pub type DefaultPRNG = rand_xorshift::XorShiftRng;
+
+pub fn with_default(
+    ctx: &(dyn Context + Send + Sync),
+    context_id: u32,
+) -> Result<Prng<DefaultPRNG>, seeding::Error> {
+    Prng::<DefaultPRNG>::new(ctx, context_id)
+}

--- a/cache-filter/src/rand/seeding.rs
+++ b/cache-filter/src/rand/seeding.rs
@@ -1,0 +1,89 @@
+use core::time::Duration;
+use std::time::SystemTime;
+
+use proxy_wasm::traits::Context;
+use rand::SeedableRng;
+use rand_jitter::{rand_core::RngCore, JitterRng};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Jitter RNG timer is invalid: {0}")]
+    JitterTimer(rand_jitter::TimerError),
+}
+
+fn generate_seed_duration(ctx: &dyn Context) -> Duration {
+    ctx.get_current_time()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_else(|e| {
+            // This can only occur if the current time is earlier than UNIX_EPOCH, iff it's even possible,
+            // but the error returns us the offset, not since but before, UNIX_EPOCH... which is ok for
+            // our purposes anyway.
+            e.duration()
+        })
+}
+
+fn create_jitter_rng<F>(
+    _ctx: &dyn Context,
+    context_id: u32,
+    f: F,
+) -> Result<(rand_jitter::JitterRng<F>, u8), Error>
+where
+    F: Fn() -> u64 + Send + Sync,
+{
+    let mut jrng = JitterRng::new_with_timer(f);
+
+    let rounds = match jrng.test_timer() {
+        Ok(rounds) => rounds,
+        Err(e) => {
+            match e {
+                rand_jitter::TimerError::CoarseTimer => {
+                    log::error!(
+                        "{}: JitterRng: timer source is coarse, seed quality will be reduced",
+                        context_id
+                    );
+                    // maximum suggested number of rounds
+                    128
+                }
+                _ => return Err(Error::JitterTimer(e)),
+            }
+        }
+    };
+
+    jrng.set_rounds(rounds);
+    let _ = jrng.next_u64();
+
+    Ok((jrng, rounds))
+}
+
+fn generate_seed_once(ctx: &(dyn Context + Send + Sync), context_id: u32) -> Result<u128, Error> {
+    let (mut jrng, rounds) = create_jitter_rng(ctx, context_id, || {
+        let ts = generate_seed_duration(ctx);
+
+        // The correct way to calculate the current time is
+        // `ts.as_secs() * 1_000_000_000 + ts.subsec_nanos() as u64`
+        // For a faster version with a very small difference in terms of
+        // entropy (log2(10^9) == 29.9) you can use:
+        // `ts.as_secs() << 30 | ts.subsec_nanos() as u64`
+        ts.as_secs() * 1_000_000_000 + ts.subsec_nanos() as u64
+    })?;
+
+    log::info!(
+        "{}: seed JitterRng configured with {} rounds",
+        context_id,
+        rounds
+    );
+
+    Ok(u128::from(jrng.next_u64()) << 64 | u128::from(jrng.next_u64()))
+}
+
+pub fn seed<R: SeedableRng>(
+    ctx: &(dyn Context + Send + Sync),
+    context_id: u32,
+) -> Result<R, Error> {
+    // hash seed with SipHash
+    use rand_seeder::Seeder;
+
+    let seed = generate_seed_once(ctx, context_id)?;
+    // seed is further hashed and then fed to the chosen RNG
+    Ok(Seeder::from(seed).make_rng())
+}

--- a/cache-filter/src/rand/thread_rng.rs
+++ b/cache-filter/src/rand/thread_rng.rs
@@ -1,0 +1,141 @@
+use super::prng::with_default;
+use super::prng::DefaultPRNG;
+use super::prng::Prng;
+use super::Context;
+use super::Error;
+
+use rand::RngCore;
+
+// Thread RNG callable from anywhere within the thread.
+// Safe to call this from different contexts as well and
+// obtain ThreadRng instances, since they will all use
+// the same thread local pseudo RNG.
+#[inline]
+#[allow(dead_code)]
+pub fn thread_rng_init_fallible(
+    ctx: &(dyn Context + Send + Sync),
+    context_id: u32,
+) -> Result<ThreadRng, Error> {
+    ThreadRng::thread_rng(ctx, context_id)
+}
+
+// Thread RNG callable from anywhere within the thread.
+// Safe to call this from different contexts as well and
+// obtain ThreadRng instances, since they will all use
+// the same thread local pseudo RNG.
+//
+// Panic: will panic if the thread local RNG could not be initialized.
+#[inline]
+#[allow(dead_code)]
+pub fn thread_rng_init(ctx: &(dyn Context + Send + Sync), context_id: u32) -> ThreadRng {
+    thread_rng_init_fallible(ctx, context_id)
+        .expect("could not initialize thread local random number generator")
+}
+
+// `ThreadRng` is a thread local pseudo random number generator seeded with
+// jitter from the clock source of a proxy-wasm context.
+//
+// The methods in this struct require the user to first initialize the thread
+// local RNG except for the constructor, thread_rng(). Failure to do so will
+// end up in a panic.
+//
+// Note that ThreadRng is a ZST. You can create as many instances as you like,
+// but they all act on the same thread local RNG, so once it is initialized for
+// a given thread you don't need to initialize it anymore.
+#[derive(Debug, Clone, Copy)]
+pub struct ThreadRng;
+
+impl ThreadRng {
+    // Construct a thread
+    #[inline]
+    pub fn thread_rng(
+        ctx: &(dyn Context + Send + Sync),
+        context_id: u32,
+    ) -> Result<Self, super::Error> {
+        imp::initialize(ctx, context_id).and(Ok(Self))
+    }
+
+    // next_u32 without using the RngCore trait which requires a mutable reference
+    #[inline]
+    pub fn next_u32(&self) -> u32 {
+        imp::next_u32()
+    }
+
+    // next_u64 without using the RngCore trait which requires a mutable reference
+    #[inline]
+    pub fn next_u64(&self) -> u64 {
+        imp::next_u64()
+    }
+
+    // Use `with` to perform multiple calls in succession to the pseudo RNG.
+    #[inline]
+    pub fn with<R, F: FnOnce(&mut Prng<DefaultPRNG>) -> R>(&self, f: F) -> R {
+        imp::rng_with(f)
+    }
+}
+
+impl RngCore for ThreadRng {
+    fn next_u32(&mut self) -> u32 {
+        (&*self).next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        (&*self).next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        imp::rng_with(|rng| rng.fill_bytes(dest))
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        imp::rng_with(|rng| rng.try_fill_bytes(dest))
+    }
+}
+
+mod imp {
+    use std::cell::RefCell;
+    use std::sync::Once;
+
+    use super::*;
+
+    thread_local! {
+        static RNG: RefCell<Option<Prng<DefaultPRNG>>> = RefCell::new(None);
+        static RNG_INIT: Once = Once::new();
+    }
+
+    pub(super) fn initialize(
+        ctx: &(dyn Context + Send + Sync),
+        context_id: u32,
+    ) -> Result<(), Error> {
+        RNG_INIT.with(|once| {
+            let mut res = Ok(());
+            once.call_once(|| {
+                res = RNG.with(|rng| {
+                    let res_rng = with_default(ctx, context_id);
+                    match res_rng {
+                        Ok(r) => {
+                            let _ = rng.borrow_mut().replace(r);
+                            Ok(())
+                        }
+                        Err(e) => Err(e),
+                    }
+                });
+            });
+            res
+        })
+    }
+
+    #[inline]
+    pub(super) fn next_u32() -> u32 {
+        rng_with(|rng| rng.next_u32())
+    }
+
+    #[inline]
+    pub(super) fn next_u64() -> u64 {
+        rng_with(|rng| rng.next_u64())
+    }
+
+    pub(super) fn rng_with<R, F: FnOnce(&mut Prng<DefaultPRNG>) -> R>(f: F) -> R {
+        RNG.with(|rng| f(rng.borrow_mut().as_mut().unwrap()))
+    }
+}


### PR DESCRIPTION
This PR takes PRNG from wasm-auth and makes it available for generating root-id/thread-id in the cache-filter.

Unique-Callout-MQ branch is for testing unique callout functionality that utilizes message queues to pass around data between different threads.