### PR TITLE
benchmark folders and files added as linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-benchmark/* linguist-vendored
+benchmark/** linguist-vendored


### PR DESCRIPTION
Ignore generated html report of benchmark from language stats