### PR TITLE
Unique Callout using MQ v0.1

### DIFF
--- a/cache-filter/src/filter/root.rs
+++ b/cache-filter/src/filter/root.rs
@@ -141,6 +141,7 @@ impl RootContext for CacheFilterRoot {
                                     self.context_id,
                                     "failed to map user_key to app_id cache key pattern: {:?}", e
                                 );
+                                waiters.remove(&context_to_resume);
                                 return;
                             }
                         }
@@ -167,6 +168,7 @@ impl RootContext for CacheFilterRoot {
                             "failed to fetch application from cache: {:?}", e
                         ),
                     }
+                    waiters.remove(&context_to_resume);
                 })
             }
             Ok(None) => warn!(

--- a/cache-filter/src/filter/root.rs
+++ b/cache-filter/src/filter/root.rs
@@ -54,6 +54,13 @@ impl RootContext for CacheFilterRoot {
         self.id = self.rng.next_u32();
         info!(self.context_id, "root initialized with id: {}", self.id);
 
+        // Initializing a thread-specific message queue
+        let queue_id = self.register_shared_queue(&self.id.to_string());
+        info!(
+            self.context_id,
+            "root({}): registered thread-specific MQ ({})", self.id, queue_id
+        );
+
         //Check for the configuration passed by envoy.yaml
         let configuration: Vec<u8> = match self.get_configuration() {
             Some(c) => c,

--- a/cache-filter/src/filter/root.rs
+++ b/cache-filter/src/filter/root.rs
@@ -1,12 +1,18 @@
 use crate::configuration::FilterConfig;
 use crate::filter::http::CacheFilter;
 use crate::rand::thread_rng::{thread_rng_init_fallible, ThreadRng};
+use crate::unique_callout::WAITING_CONTEXTS;
+use crate::utils::request_process_failure;
 use crate::{debug, info, warn};
 use proxy_wasm::{
+    hostcalls::set_effective_context,
     traits::{Context, HttpContext, RootContext},
     types::{ContextType, LogLevel},
 };
-use threescale::{proxy::CacheKey, structs::ThreescaleData};
+use threescale::{
+    proxy::{get_app_id_from_cache, get_application_from_cache, CacheKey},
+    structs::{AppIdentifier, ThreescaleData},
+};
 
 #[no_mangle]
 pub fn _start() {
@@ -87,6 +93,90 @@ impl RootContext for CacheFilterRoot {
                 );
                 true
             }
+        }
+    }
+
+    fn on_queue_ready(&mut self, queue_id: u32) {
+        info!(
+            self.context_id,
+            "thread({}): on_queue called on the filter side", self.id
+        );
+        match self.dequeue_shared_queue(queue_id) {
+            Ok(Some(bytes)) => {
+                let ctxt_str = std::str::from_utf8(&bytes).unwrap();
+                let context_to_resume: u32 = match ctxt_str.parse() {
+                    Ok(ctxt_id) => ctxt_id,
+                    Err(e) => {
+                        warn!(
+                            self.context_id,
+                            "failed to parse message({}) from MQ into ctxt id: {}", ctxt_str, e
+                        );
+                        return;
+                    }
+                };
+
+                WAITING_CONTEXTS.with(|refcell| {
+                    let mut waiters = refcell.borrow_mut();
+                    let context = waiters.get_mut(&context_to_resume);
+                    if context.is_none() {
+                        warn!(
+                            self.context_id,
+                            "http context({}) not found while resuming after callout response",
+                            context_to_resume
+                        );
+                        return;
+                    }
+                    let context = context.unwrap();
+
+                    // Waiting contexts can have cache_key with user_key pattern but cache stores
+                    // application only with app_id pattern so change if required before accessing it.
+                    if let AppIdentifier::UserKey(ref user_key) = context.cache_key.app_id() {
+                        match get_app_id_from_cache(user_key) {
+                            Ok(app_id) => {
+                                context.cache_key.set_app_id(&AppIdentifier::from(app_id))
+                            }
+                            Err(e) => {
+                                // This is unlikely since mapping is defined when auth response is handled.
+                                warn!(
+                                    self.context_id,
+                                    "failed to map user_key to app_id cache key pattern: {:?}", e
+                                );
+                                return;
+                            }
+                        }
+                    }
+                    match get_application_from_cache(&context.cache_key) {
+                        Ok((mut app, cas)) => {
+                            if let Err(e) = set_effective_context(context_to_resume) {
+                                // NOTE: Ideally this should not happen.
+                                warn!(
+                                    context_to_resume,
+                                    "failed to set effective context in the host: {:?}", e
+                                );
+                            } else if let Err(e) = context.handle_cache_hit(&mut app, cas) {
+                                debug!(context_to_resume, "handle_cache_hit fail: {}", e);
+                                // if there is error from handle_cache_hit, request flow is not changed
+                                // and should be done by the code handling the returned error.
+                                request_process_failure(context, context);
+                            } else {
+                                context.resume_http_request();
+                            }
+                        }
+                        Err(e) => warn!(
+                            context_to_resume,
+                            "failed to fetch application from cache: {:?}", e
+                        ),
+                    }
+                })
+            }
+            Ok(None) => warn!(
+                self.context_id,
+                "on_queue called but found nothing in the MQ"
+            ),
+            Err(e) => warn!(
+                self.context_id,
+                "failed to dequeue from thread-specific MQ: {:?}", e
+            ),
         }
     }
 

--- a/cache-filter/src/lib.rs
+++ b/cache-filter/src/lib.rs
@@ -1,4 +1,7 @@
 #![deny(clippy::all, clippy::cargo)]
+
+const VM_ID: &str = "my_vm_id";
+
 mod configuration;
 mod filter;
 mod log;

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -239,6 +239,12 @@ pub fn add_to_callout_waitlist(context: &CacheFilter) -> Result<(), UniqueCallou
                         if let Err(Status::CasMismatch) =
                             set_shared_data(&waiters_key, Some(&serialized_cw), Some(cas))
                         {
+                            debug!(
+                                context.context_id,
+                                "thread({}): CAS mismatch while add callout-waiter({})",
+                                context.root_id,
+                                waiters_key
+                            );
                             continue;
                         }
                         break;
@@ -271,6 +277,12 @@ pub fn add_to_callout_waitlist(context: &CacheFilter) -> Result<(), UniqueCallou
                 if let Err(Status::CasMismatch) =
                     set_shared_data(&waiters_key, Some(&serialized_cw), Some(cas))
                 {
+                    debug!(
+                        context.context_id,
+                        "thread({}): CAS mismatch while adding the first callout-waiter({})",
+                        context.root_id,
+                        waiters_key
+                    );
                     continue;
                 }
                 break;
@@ -328,8 +340,9 @@ pub fn resume_callout_waiters(
         },
         Ok((None, _)) => {
             // This can happen either someother thread freed waiting contexts or
-            // there was only 1 request for this specific application.
-            debug!(
+            // there was only 1 request for this specific application. If this happens
+            // check implementation of acquiring and freeing lock as it's not supposed to happen.
+            warn!(
                 context_id,
                 "thread({}): found no callout-waiters ({})", root_id, waiters_key
             );

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -166,6 +166,7 @@ pub fn free_callout_lock(
     root_id: u32,
     context_id: u32,
     cache_key: &CacheKey,
+) -> Result<(), UniqueCalloutError> {
     let callout_key = format!("CL_{}", cache_key.as_string());
     info!(
         context_id,
@@ -177,7 +178,7 @@ pub fn free_callout_lock(
             context_id,
             "thread ({}): trying to free non-existing callout-lock ({})", root_id, callout_key
         );
-        return Err(Status::NotFound);
+        return Err(UniqueCalloutError::ProxyFailure(Status::NotFound));
     }
 
     if let Err(e) = set_shared_data(&callout_key, None, None) {
@@ -188,7 +189,10 @@ pub fn free_callout_lock(
             callout_key,
             e
         );
-        return Err(e);
+        return Err(UniqueCalloutError::ProxyFailure(e));
+    }
+    Ok(())
+}
     }
     Ok(())
 }

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -9,6 +9,24 @@ thread_local! {
     pub static WAITING_CONTEXTS: RefCell<HashMap<u32, CacheFilter>> = RefCell::new(HashMap::new());
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum UniqueCalloutError<'a> {
+    #[error("failed to serialize {what:?} due to {reason:?}")]
+    SerializeFail {
+        what: &'a str,
+        reason: bincode::ErrorKind,
+    },
+    #[error("failed to deserialize {what:?} due to {reason:?}")]
+    DeserializeFail {
+        what: &'a str,
+        reason: bincode::ErrorKind,
+    },
+    #[error("failure due to proxy's internal issue: {0:?}")]
+    ProxyFailure(Status),
+    #[error("failed to resolve thread({0}) specific MQ while adding callout-waiter")]
+    MQResolveFail(u32),
+}
+
 // This struct is serialized and stored in the shared data for callout-lock winner
 // to know which thread to wake up and to let waiters know which http context to resume processing.
 #[derive(Deserialize, Serialize, Clone)]

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -5,6 +5,16 @@ use proxy_wasm::{
 };
 use threescale::proxy::CacheKey;
 
+// This struct is serialized and stored in the shared data for callout-lock winner
+// to know which thread to wake up and to let waiters know which http context to resume processing.
+#[derive(Deserialize, Serialize, Clone)]
+pub struct CalloutWaiter {
+    /// MQ id of the thread waiting for callout response.
+    pub queue_id: u32,
+    /// Id of http context waiting for callout response.
+    pub http_context_id: u32,
+}
+
 /** TD;LR on how lock is acquired by exploiting host implementation:
 * cache is essentially a hashmap that maps key to a pair of (value, cas).
 * set_shared_data(key, value, cas)'s psuedo-code is as follows:

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -5,6 +5,10 @@ use proxy_wasm::{
 };
 use threescale::proxy::CacheKey;
 
+thread_local! {
+    pub static WAITING_CONTEXTS: RefCell<HashMap<u32, CacheFilter>> = RefCell::new(HashMap::new());
+}
+
 // This struct is serialized and stored in the shared data for callout-lock winner
 // to know which thread to wake up and to let waiters know which http context to resume processing.
 #[derive(Deserialize, Serialize, Clone)]

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -24,7 +24,7 @@ use threescale::proxy::CacheKey;
 * If you go through above-mentioned algo, no matter the order which thread executes first, second thread
 * will overwrite the first one because None CAS is translated into 0 in SDK and second-if condition is passed-over.
 
-* Now imagine if T1 & T2 use '1'(any but 0) as CAS, first thread will insert a new entry since it's not 
+* Now imagine if T1 & T2 use '1'(any but 0) as CAS, first thread will insert a new entry since it's not
 * already present in the hashmap and second one will get CasMismatch in the result due to second-if condition.
 * NOTE: Since CAS is a u32 integer, after u32::MAX, CAS resets to 1. What this means for unique-callout
 * is that N threads can successfully acquire the lock again when lock was freed with CAS=1. But the chances

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -16,7 +16,12 @@ use threescale::proxy::CacheKey;
 *   else insert_new_entry_into_the_hashmap
 *
 * A lock is acquired by a thread when it successfully adds an entry in the cache of the format:
-*              ("callout_{CacheKey}", ({THREAD_ID/ROOT_CONTEXT_ID}, CAS))
+*              ("CL_{CacheKey}", ({THREAD_ID/ROOT_CONTEXT_ID}, CAS))
+
+* Rest of the threads that don't the lock will have their ids stored in the cache with format:
+*              ("CW_{CacheKey}", (serialized_vector_of_CalloutWaiter_struct, CAS))
+
+* Here, CL - Callout-Lock, CW - Callout-Waiters
 
 * If you look at Rust SDK spec, when a cache entry is not present, you get (None, None) as result.
 * Now imagine a scenario, when two threads (T1 & T2) check for the same lock in the cache and find no lock.

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -1,8 +1,12 @@
-use crate::{info, warn};
+use crate::filter::http::CacheFilter;
+use crate::{debug, info, warn};
 use proxy_wasm::{
-    hostcalls::{get_shared_data, set_shared_data},
+    hostcalls::{enqueue_shared_queue, get_shared_data, resolve_shared_queue, set_shared_data},
     types::Status,
 };
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::collections::HashMap;
 use threescale::proxy::CacheKey;
 
 thread_local! {


### PR DESCRIPTION
This PR implements the first version of the working unique callout feature using message queues.

Note: There are cases in which resuming a waiting context fails and request stays in the state of limbo (e.g. if auth callout timeouts). These cases will be slowly fixed since PR is already very large and needs review before moving forward.