### PR TITLE
Simplifying request failure methods

### DIFF
--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -135,10 +135,10 @@ impl HttpContext for CacheFilter {
             Ok((mut app, cas)) => match self.handle_cache_hit(&mut app, cas) {
                 Ok(()) => Action::Continue,
                 Err(e) => {
-                        in_request_failure(self, self)
-                    }
+                    warn!(self.context_id, "cache hit flow failed: {}", e);
+                    in_request_failure(self)
                 }
-            }
+            },
             Err(e) => {
                 info!(self.context_id, "cache miss: {}", e);
                 // TODO: Avoid multiple calls for same application
@@ -411,7 +411,7 @@ impl Context for CacheFilter {
                                         self.context_id,
                                         "handling auth response failed: {:?}", e
                                     );
-                                    request_process_failure(self, self)
+                                    request_process_failure(self)
                                 }
                             } else if cfg!(feature = "visible_logs") {
                                 let (key, val) =
@@ -436,7 +436,7 @@ impl Context for CacheFilter {
                                 "authorization error with code: {}",
                                 auth_error.code()
                             );
-                            request_process_failure(self, self);
+                            request_process_failure(self);
                             return;
                         }
                         Err(e) => {
@@ -446,7 +446,7 @@ impl Context for CacheFilter {
                                 e,
                                 token_id
                             );
-                            request_process_failure(self, self);
+                            request_process_failure(self);
                             return;
                         }
                     }
@@ -461,7 +461,7 @@ impl Context for CacheFilter {
                         self.context_id,
                         "Found nothing in the response with token: {}", token_id
                     );
-                    request_process_failure(self, self);
+                    request_process_failure(self);
                 }
             }
         } else {


### PR DESCRIPTION
This PR simplifies request failure methods to use only 1 ref to CacheFilter object instead of two.

Also, cache hit log, and metric is moved to a better location.