### PR TITLE
Cleaning up redundant code pertaining to visible logs

### DIFF
--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -106,14 +106,7 @@ impl HttpContext for CacheFilter {
                 debug!(self.context_id, "fetching request data failed: {}", e);
                 increment_stat(&self.stats.auth_metadata_errors);
                 // Send back local response for not providing relevant request data
-                if cfg!(feature = "visible_logs") {
-                    let (key, val) =
-                        crate::log::visible_logs::get_logs_header_pair(self.context_id);
-                    self.send_http_response(401, vec![(key.as_ref(), val.as_ref())], None);
-                } else {
-                    self.send_http_response(401, vec![], None);
-                }
-
+                self.send_http_response(401, vec![], None);
                 return Action::Pause;
             }
         };
@@ -488,14 +481,6 @@ impl Context for CacheFilter {
                                 } else {
                                     waiter_action = WaiterAction::HandleCacheHit(0);
                                 }
-                            } else if cfg!(feature = "visible_logs") {
-                                let (key, val) =
-                                    crate::log::visible_logs::get_logs_header_pair(self.context_id);
-                                self.send_http_response(
-                                    403,
-                                    vec![(key.as_ref(), val.as_ref())],
-                                    Some(response.reason().unwrap().as_bytes()),
-                                );
                             } else {
                                 increment_stat(&self.stats.unauthorized);
                                 self.send_http_response(

--- a/cache-filter/src/log.rs
+++ b/cache-filter/src/log.rs
@@ -78,14 +78,3 @@ pub fn __custom_log(context: u32, args: std::fmt::Arguments, level: LogLevel) {
     visible_logs::store_logs(context, &message);
     proxy_wasm::hostcalls::log(level, &message).unwrap();
 }
-
-// This is required for clean use of cfg! with visible_logs module
-#[cfg(not(feature = "visible_logs"))]
-pub mod visible_logs {
-    pub fn get_logs_header_pair(_: u32) -> (String, String) {
-        (
-            "enable visible_logs".to_string(),
-            "using cargo flags first".to_string(),
-        )
-    }
-}

--- a/cache-filter/src/utils.rs
+++ b/cache-filter/src/utils.rs
@@ -20,17 +20,7 @@ use threescalers::{
 // Helper function to handle failure when request headers are recieved
 pub fn in_request_failure(filter: &CacheFilter) -> Action {
     if filter.config.failure_mode_deny {
-        if cfg!(feature = "visible_logs") {
-            let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
-            send_http_response(
-                403,
-                vec![(key.as_ref(), val.as_ref())],
-                Some(b"Access forbidden.\n"),
-            )
-            .unwrap(); // Safe for current implementation.
-        } else {
-            send_http_response(403, vec![], Some(b"Access forbidden.\n")).unwrap();
-        }
+        send_http_response(403, vec![], Some(b"Access forbidden.\n")).unwrap();
         return Action::Pause;
     }
     Action::Continue
@@ -39,17 +29,7 @@ pub fn in_request_failure(filter: &CacheFilter) -> Action {
 // Helper function to handle failure during processing
 pub fn request_process_failure(filter: &CacheFilter) {
     if filter.config.failure_mode_deny {
-        if cfg!(feature = "visible_logs") {
-            let (key, val) = crate::log::visible_logs::get_logs_header_pair(filter.context_id);
-            send_http_response(
-                403,
-                vec![(key.as_ref(), val.as_ref())],
-                Some(b"Access forbidden.\n"),
-            )
-            .unwrap(); //
-        } else {
-            send_http_response(403, vec![], Some(b"Access forbidden.\n")).unwrap();
-        }
+        send_http_response(403, vec![], Some(b"Access forbidden.\n")).unwrap();
     }
     resume_http_request().unwrap();
 }


### PR DESCRIPTION
Since on_http_response_headers() can itself add the stored logs onto the response headers, there is no need of dead code to take care of scenario when this feature is disabled. Just a clean up and should not break anything :)