### PR TITLE
Adding RateLimit headers and few simplifications

### DIFF
--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -86,16 +86,26 @@ pub enum RequestDataError {
     UpstreamBuilderFail(#[from] threescalers::Error),
 }
 
+/// State data collected/updated during a request lifetime.
+#[derive(Clone)]
+pub struct RequestState {
+    /// Set to true if all tries fail to update cache from the filter.
+    pub update_cache_from_singleton: bool,
+    /// Request metadata. Saved for availability after callout.
+    pub req_data: ThreescaleData,
+    /// Created using request metadata received. Saved for performance.
+    pub cache_key: CacheKey,
+    /// RateLimit header values. Calculated in limit_check_and_update_app.
+    pub rate_limit_info: RateLimitInfo,
+}
+
 #[derive(Clone)]
 pub struct CacheFilter {
     pub context_id: u32,
     pub root_id: u32,
     pub config: FilterConfig,
-    pub update_cache_from_singleton: bool,
-    pub cache_key: CacheKey,
-    // required for cache miss case
-    pub req_data: ThreescaleData,
     pub stats: ThreescaleStats,
+    pub state: RequestState,
 }
 
 impl HttpContext for CacheFilter {

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -110,6 +110,10 @@ pub struct CacheFilter {
 
 impl HttpContext for CacheFilter {
     fn on_http_request_headers(&mut self, _: usize) -> Action {
+        info!(
+            self.context_id,
+            "thread({}): on_http_request_headers", self.root_id
+        );
         let mut request_data = match self.get_request_data() {
             Ok(data) => data,
             Err(e) => {
@@ -121,15 +125,15 @@ impl HttpContext for CacheFilter {
             }
         };
 
-        self.cache_key = CacheKey::from(&request_data.service_id, &request_data.app_id);
-        self.req_data = request_data.clone();
+        self.state.cache_key = CacheKey::from(&request_data.service_id, &request_data.app_id);
+        self.state.req_data = request_data.clone();
 
         if let AppIdentifier::UserKey(ref user_key) = request_data.app_id {
             match get_app_id_from_cache(user_key) {
                 Ok(app_id) => {
                     request_data.app_id = AppIdentifier::from(app_id);
-                    self.req_data.app_id = request_data.app_id.clone();
-                    self.cache_key.set_app_id(&request_data.app_id);
+                    self.state.req_data.app_id = request_data.app_id.clone();
+                    self.state.cache_key.set_app_id(&request_data.app_id);
                 }
                 Err(e) => {
                     debug!(
@@ -146,8 +150,8 @@ impl HttpContext for CacheFilter {
                             match get_app_id_from_cache(user_key) {
                                 Ok(app_id) => {
                                     request_data.app_id = AppIdentifier::from(app_id);
-                                    self.req_data.app_id = request_data.app_id.clone();
-                                    self.cache_key.set_app_id(&request_data.app_id);
+                                    self.state.req_data.app_id = request_data.app_id.clone();
+                                    self.state.cache_key.set_app_id(&request_data.app_id);
                                 }
                                 Err(e) => {
                                     debug!(self.context_id, "user_key->app_id mapping not found after callout response: {:?}", e);
@@ -159,7 +163,7 @@ impl HttpContext for CacheFilter {
                             warn!(
                                 self.context_id,
                                 "failed to set callout-lock or add to waitlist for request(key: {}): {:?}",
-                                self.cache_key.as_string(),
+                                self.state.cache_key.as_string(),
                                 e
                             );
                             return in_request_failure(self);
@@ -169,7 +173,7 @@ impl HttpContext for CacheFilter {
             }
         }
 
-        match get_application_from_cache(&self.cache_key) {
+        match get_application_from_cache(&self.state.cache_key) {
             Ok((mut app, cas)) => match self.handle_cache_hit(&mut app, cas) {
                 Ok(()) => Action::Continue,
                 Err(e) => {
@@ -186,7 +190,7 @@ impl HttpContext for CacheFilter {
                     }
                     Ok(SetCalloutLockStatus::AddedToWaitlist) => Action::Pause,
                     Ok(SetCalloutLockStatus::ResponseCameFirst) => {
-                        match get_application_from_cache(&self.cache_key) {
+                        match get_application_from_cache(&self.state.cache_key) {
                             Ok((mut app, cas)) => match self.handle_cache_hit(&mut app, cas) {
                                 Ok(()) => Action::Continue,
                                 Err(e) => {
@@ -207,7 +211,7 @@ impl HttpContext for CacheFilter {
                         warn!(
                             self.context_id,
                             "failed to set callout-lock for request(key: {}): {:?}",
-                            self.cache_key.as_string(),
+                            self.state.cache_key.as_string(),
                             e
                         );
                         in_request_failure(self)
@@ -227,8 +231,11 @@ impl HttpContext for CacheFilter {
 
 impl CacheFilter {
     fn report_to_singleton(&self, qid: u32, req_time: &Duration) -> bool {
-        let message: Message =
-            Message::new(self.update_cache_from_singleton, &self.req_data, req_time);
+        let message: Message = Message::new(
+            self.state.update_cache_from_singleton,
+            &self.state.req_data,
+            req_time,
+        );
         if let Err(e) = self.enqueue_shared_queue(qid, Some(&bincode::serialize(&message).unwrap()))
         {
             warn!(
@@ -257,14 +264,14 @@ impl CacheFilter {
         let mut rate_limited = false;
         let max_tries = self.config.max_tries;
 
-        add_hierarchy_to_metrics(&app.metric_hierarchy, &mut self.req_data.metrics);
+        add_hierarchy_to_metrics(&app.metric_hierarchy, &mut self.state.req_data.metrics);
 
         // In case of CAS mismatch, new application needs to be fetched and modified again.
         for num_try in 0..max_tries {
-            match limit_check_and_update_application(&self.req_data, app, app_cas, &current_time) {
-                Ok(()) => {
+                &self.state.req_data,
                     // App is not rate-limited and updated in cache.
                     info!(self.context_id, "request is allowed to pass the filter");
+                    self.state.rate_limit_info = rate_limit_info;
                     if app_cas == 0 {
                         increment_stat(&self.stats.cached_apps)
                     }
@@ -279,6 +286,7 @@ impl CacheFilter {
                 }
                 Err(UpdateMetricsError::RateLimited) => {
                     info!(self.context_id, "request is rate-limited");
+                    self.state.rate_limit_info = rate_limit_info;
                     self.send_http_response(429, vec![], Some(b"Request rate-limited.\n"));
                     // no need to retry if already rate-limted
                     rate_limited = true;
@@ -293,7 +301,7 @@ impl CacheFilter {
                         reason
                     );
                     if num_try < max_tries {
-                        match get_application_from_cache(&self.cache_key) {
+                        match get_application_from_cache(&self.state.cache_key) {
                             Ok((new_app, cas)) => {
                                 *app = new_app;
                                 app_cas = cas;
@@ -310,7 +318,7 @@ impl CacheFilter {
         // Singleton will try to overwrite and in the mean time till singleton receives
         // the message, hopefully, contention will reduce.
         if !updated_cache && !rate_limited {
-            self.update_cache_from_singleton = true;
+            self.state.update_cache_from_singleton = true;
             self.resume_http_request();
         }
         Ok(())
@@ -338,12 +346,12 @@ impl CacheFilter {
         );
 
         // change user_key to app_id for further processing
-        if let AppIdentifier::UserKey(user_key) = self.cache_key.app_id() {
-            self.req_data.app_id = app_identifier.clone();
+        if let AppIdentifier::UserKey(user_key) = self.state.cache_key.app_id() {
+            self.state.req_data.app_id = app_identifier.clone();
             set_app_id_to_cache(user_key, &app_id)?;
         }
 
-        self.cache_key = CacheKey::from(&service_id, &app_identifier);
+        self.state.cache_key = CacheKey::from(&service_id, &app_identifier);
 
         if let Some(reports) = response.usage_reports() {
             for usage in reports {
@@ -464,7 +472,7 @@ impl Context for CacheFilter {
 
         // Freeing of callout-lock requires the cache_key used to set the lock but cache_key
         // attached to 'self' can change inside handle_auth_response (user_key to app_id).
-        let prev_cache_key = self.cache_key.clone();
+        let prev_cache_key = self.state.cache_key.clone();
 
         // Depending on how response is handled here, waiters should resume accordingly.
         // Note: Inner value of this enum is changed to context_id to resume in send_action_to_waiters().

--- a/cache-filter/src/filter/http.rs
+++ b/cache-filter/src/filter/http.rs
@@ -58,7 +58,7 @@ enum AuthResponseError {
     ListKeysMiss,
     #[error("app id field is missing from list keys extension response")]
     ListAppIdMiss,
-    #[error("app id field is missing from list keys extension response")]
+    #[error("service id field is missing from list keys extension response")]
     ListServiceIdMiss,
     #[error("failed to map user_key to app_id in the cache")]
     AppIdNotMapped(#[from] CacheError),
@@ -143,7 +143,7 @@ impl HttpContext for CacheFilter {
                     increment_stat(&self.stats.cache_misses);
                     match set_callout_lock(self) {
                         Ok(SetCalloutLockStatus::LockAcquired) => {
-                            return do_auth_call(self, self, &request_data);
+                            return do_auth_call(self);
                         }
                         Ok(SetCalloutLockStatus::AddedToWaitlist) => return Action::Pause,
                         Ok(SetCalloutLockStatus::ResponseCameFirst) => {
@@ -185,9 +185,7 @@ impl HttpContext for CacheFilter {
                 info!(self.context_id, "cache miss: {}", e);
                 increment_stat(&self.stats.cache_misses);
                 match set_callout_lock(self) {
-                    Ok(SetCalloutLockStatus::LockAcquired) => {
-                        do_auth_call(self, self, &request_data)
-                    }
+                    Ok(SetCalloutLockStatus::LockAcquired) => do_auth_call(self),
                     Ok(SetCalloutLockStatus::AddedToWaitlist) => Action::Pause,
                     Ok(SetCalloutLockStatus::ResponseCameFirst) => {
                         match get_application_from_cache(&self.state.cache_key) {

--- a/cache-filter/src/filter/root.rs
+++ b/cache-filter/src/filter/root.rs
@@ -159,10 +159,10 @@ impl RootContext for CacheFilterRoot {
 
                     // Waiting contexts can have cache_key with user_key pattern but cache stores
                     // application only with app_id pattern so change if required before accessing it.
-                    if let AppIdentifier::UserKey(ref user_key) = context.cache_key.app_id() {
+                    if let AppIdentifier::UserKey(ref user_key) = context.state.cache_key.app_id() {
                         match get_app_id_from_cache(user_key) {
                             Ok(app_id) => {
-                                context.cache_key.set_app_id(&AppIdentifier::from(app_id))
+                                context.state.cache_key.set_app_id(&AppIdentifier::from(app_id))
                             }
                             Err(e) => {
                                 // This is unlikely since mapping is defined when auth response is handled properly.
@@ -177,7 +177,7 @@ impl RootContext for CacheFilterRoot {
                         }
                     }
 
-                    match get_application_from_cache(&context.cache_key) {
+                    match get_application_from_cache(&context.state.cache_key) {
                         Ok((mut app, cas)) => {
                             if let Err(e) = context.handle_cache_hit(&mut app, cas) {
                                 debug!(context_to_resume, "handle_cache_hit fail: {}", e);

--- a/cache-filter/src/filter/root.rs
+++ b/cache-filter/src/filter/root.rs
@@ -1,12 +1,16 @@
 use crate::configuration::FilterConfig;
-use crate::filter::http::CacheFilter;
+use crate::filter::http::{CacheFilter, RequestState};
 use crate::rand::thread_rng::{thread_rng_init_fallible, ThreadRng};
 use crate::{debug, info, warn};
 use proxy_wasm::{
     traits::{Context, HttpContext, RootContext},
     types::{ContextType, LogLevel},
 };
-use threescale::{proxy::CacheKey, stats::*, structs::ThreescaleData};
+use threescale::{
+    proxy::CacheKey,
+    stats::*,
+    structs::{RateLimitInfo, ThreescaleData},
+};
 
 #[no_mangle]
 pub fn _start() {
@@ -212,9 +216,12 @@ impl RootContext for CacheFilterRoot {
             context_id: context,
             root_id: self.id,
             config: self.config.clone(),
-            update_cache_from_singleton: false,
-            cache_key: CacheKey::default(),
-            req_data: ThreescaleData::default(),
+            state: RequestState {
+                update_cache_from_singleton: false,
+                cache_key: CacheKey::default(),
+                req_data: ThreescaleData::default(),
+                rate_limit_info: RateLimitInfo::default(),
+            },
             stats: self.stats.clone(),
         }))
     }

--- a/cache-filter/src/unique_callout.rs
+++ b/cache-filter/src/unique_callout.rs
@@ -104,7 +104,7 @@ pub enum SetCalloutLockStatus {
 // Callout lock is acquired by placing a key-value pair inside shared data.
 // Return Ok(true) when lock is acquired and Ok(false) when added to waitlist.
 pub fn set_callout_lock(context: &CacheFilter) -> Result<SetCalloutLockStatus, UniqueCalloutError> {
-    let callout_lock_key = format!("CL_{}", context.cache_key.as_string());
+    let callout_lock_key = format!("CL_{}", context.state.cache_key.as_string());
     let context_id = context.context_id;
     let root_id = context.root_id;
     info!(

--- a/singleton-service/src/service/proxy.rs
+++ b/singleton-service/src/service/proxy.rs
@@ -289,7 +289,7 @@ impl SingletonService {
                     cas,
                     req_time,
                 ) {
-                    Ok(()) => Ok(()),
+                    Ok(_) => Ok(()),
                     Err(UpdateMetricsError::CacheUpdateFail(reason)) => {
                         anyhow::bail!(SingletonServiceError::SetCacheFailure(
                             cache_key.as_string(),

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -273,3 +273,9 @@ impl Default for RateLimitInfo {
         }
     }
 }
+
+// Signifies whether rate-limit a request or not.
+pub enum RateLimitStatus {
+    Authorized(RateLimitInfo),
+    RateLimited(RateLimitInfo),
+}

--- a/threescale/src/structs.rs
+++ b/threescale/src/structs.rs
@@ -252,3 +252,24 @@ impl Message {
         }
     }
 }
+
+// Info relevant for the RateLimit headers.
+#[derive(Clone)]
+pub struct RateLimitInfo {
+    /// Header RateLimit-Limit's value.
+    pub limit: Option<u64>,
+    /// Header RateLimit-Remaining's value.
+    pub remaining: Option<u64>,
+    /// Header RateLimit-Reset's value.
+    pub reset: Option<u64>,
+}
+
+impl Default for RateLimitInfo {
+    fn default() -> Self {
+        RateLimitInfo {
+            limit: None,
+            remaining: None,
+            reset: None,
+        }
+    }
+}

--- a/threescale/src/utils.rs
+++ b/threescale/src/utils.rs
@@ -1,5 +1,7 @@
 use crate::proxy::{set_application_to_cache, CacheKey};
-use crate::structs::{Application, Hierarchy, Metrics, Period, ThreescaleData};
+use crate::structs::{
+    Application, Hierarchy, Metrics, Period, RateLimitInfo, RateLimitStatus, ThreescaleData,
+};
 use std::time::Duration;
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -19,7 +21,9 @@ pub fn limit_check_and_update_application(
     app: &mut Application,
     app_cas: u32,
     current_time: &Duration,
-) -> Result<(), UpdateMetricsError> {
+) -> Result<RateLimitStatus, UpdateMetricsError> {
+    let mut rate_limit_info = RateLimitInfo::default();
+
     for (metric, hits) in data.metrics.borrow().iter() {
         // note: we assume missing metrics are not limited until new state is fetched
         if let Some(usage_report) = app.local_state.get_mut(metric) {
@@ -53,9 +57,24 @@ pub fn limit_check_and_update_application(
             }
 
             if usage_report.left_hits < *hits {
-                return Err(UpdateMetricsError::RateLimited);
+                rate_limit_info.limit = Some(usage_report.max_value);
+                rate_limit_info.remaining = Some(0);
+                // Current time is between period window since it's already adjusted.
+                rate_limit_info.reset =
+                    Some(period.end.checked_sub(*current_time).unwrap().as_secs());
+                return Ok(RateLimitStatus::RateLimited(rate_limit_info));
             }
             usage_report.left_hits -= *hits;
+
+            // RateLimit-Limit must convey minimum service-limit.
+            if rate_limit_info.limit.is_none()
+                || usage_report.max_value < rate_limit_info.limit.unwrap()
+            {
+                rate_limit_info.limit = Some(usage_report.max_value);
+                rate_limit_info.remaining = Some(usage_report.left_hits);
+                rate_limit_info.reset =
+                    Some(period.end.checked_sub(*current_time).unwrap().as_secs());
+            }
         }
     }
 
@@ -64,7 +83,7 @@ pub fn limit_check_and_update_application(
     if let Err(e) = set_application_to_cache(&cache_key.as_string(), app, app_cas) {
         return Err(UpdateMetricsError::CacheUpdateFail(e.to_string()));
     }
-    Ok(())
+    Ok(RateLimitStatus::Authorized(rate_limit_info))
 }
 
 // It takes the provided hierarchy structure, and uses it

--- a/threescale/src/utils.rs
+++ b/threescale/src/utils.rs
@@ -30,7 +30,11 @@ pub fn limit_check_and_update_application(
                 let time_diff = current_time
                     .checked_sub(period.start)
                     .ok_or(UpdateMetricsError::DurationOverflow)?;
+
+                // This is atleast 1 because current time is higher than window end.
                 let num_windows = time_diff.as_secs() / period.window.as_secs();
+
+                // No. of secs to push forward window ends so the current time fall within new window.
                 let seconds_to_add = num_windows * period.window.as_secs();
 
                 // set to new period window


### PR DESCRIPTION
It was part of the TODOs in GSoC to add RateLimit headers, but it was put on hold to prioritize other work. I have tried to add a very basic implementation of them considering the complex 3scale data model. The filter will include these headers as long as there is no internal failure.

Let me know if I missed something. Thanks!